### PR TITLE
Remove useradd requirement and use addUserAccount

### DIFF
--- a/packages/openssh/SPECS/openssh.spec
+++ b/packages/openssh/SPECS/openssh.spec
@@ -277,7 +277,7 @@ Requires: openssh = %{version}-%{release}
 %package server
 Summary: An open source SSH server daemon
 Requires: openssh = %{version}-%{release}
-Requires(pre): /usr/sbin/useradd
+#Requires(pre): /usr/sbin/useradd
 #Requires: pam >= 1.0.1-3
 #Requires: fipscheck-lib%{_isa} >= 1.3.0
 #Requires: crypto-policies >= 20180306-1
@@ -634,8 +634,12 @@ getent group ssh_keys >/dev/null || groupadd -r ssh_keys || :
 %pre server
 getent group sshd >/dev/null || groupadd -g %{sshd_uid} -r sshd || :
 getent passwd sshd >/dev/null || \
-  useradd -c "Privilege-separated SSH" -u %{sshd_uid} -g sshd \
-  -s /sbin/nologin -r -d /var/empty/sshd sshd 2> /dev/null || :
+#  useradd -c "Privilege-separated SSH" -u %{sshd_uid} -g sshd \
+#  -s /sbin/nologin -r -d /var/empty/sshd sshd 2> /dev/null || :
+  /usr/sysadm/privbin/addUserAccount -l sshd -u %{sshd_uid} \
+  -g %{sshd_gid} -G "Privilege-separated SSH" -S /bin/false \
+  -H /var/empty/sshd 2> /dev/null || :
+
 
 #%post server
 #%systemd_post sshd.service sshd.socket


### PR DESCRIPTION
`useradd` isn't present in IRIX, so the rpm won't want to install as it doesn't exist. Furthermore, let's use IRIX's `addUserAccount` to create the privilege separation user.