### PR TITLE
Upgrade of libdicl to 0.1.19 for strto* functionality

### DIFF
--- a/packages/chkconfig/SPECS/chkconfig.spec
+++ b/packages/chkconfig/SPECS/chkconfig.spec
@@ -4,14 +4,14 @@
 Summary: A system tool for maintaining the /etc/rc*.d hierarchy
 Name: chkconfig
 Version: 1.11
-Release: 5%{?dist}
+Release: 6%{?dist}
 License: GPLv2
 URL: https://github.com/fedora-sysv/chkconfig
 Source: https://github.com/fedora-sysv/chkconfig/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 #BuildRequires: newt-devel gettext popt-devel libselinux-devel beakerlib gcc
 Conflicts: initscripts <= 5.30-1
-BuildRequires: libdicl-devel
-Requires:      libdicl
+BuildRequires: libdicl-devel >= 0.1.19
+Requires:      libdicl >= 0.1.19
 
 Patch0:        chkconfig.sgifixes.patch
 
@@ -21,11 +21,11 @@ information for system services.  Chkconfig manipulates the numerous
 symbolic links in /etc/rc.d, to relieve system administrators of some 
 of the drudgery of manually editing the symbolic links.
 
-#%package -n ntsysv
+#%%package -n ntsysv
 #Summary: A tool to set the stop/start of system services in a runlevel
 #Requires: chkconfig = %{version}-%{release}
 
-#%description -n ntsysv
+#%%description -n ntsysv
 #Ntsysv provides a simple interface for setting which system services
 #are started or stopped in various runlevels (instead of directly
 #manipulating the numerous symbolic links in /etc/rc.d). Unless you
@@ -100,12 +100,12 @@ rm $RPM_BUILD_ROOT%{_mandir}/man8/ntsysv*
 #/etc/rc[0-6].d
 #/etc/rc.d/rc[0-6].d
 %{_mandir}/*/chkconfig*
-#%{_prefix}/lib/systemd/systemd-sysv-install
+#%%{_prefix}/lib/systemd/systemd-sysv-install
 
-#%files -n ntsysv
-#%defattr(-,root,root)
-#%{_sbindir}/ntsysv
-#%{_mandir}/*/ntsysv.8*
+#%%files -n ntsysv
+#%%defattr(-,root,root)
+#%%{_sbindir}/ntsysv
+#%%{_mandir}/*/ntsysv.8*
 
 %files -n alternatives
 %license COPYING
@@ -117,6 +117,9 @@ rm $RPM_BUILD_ROOT%{_mandir}/man8/ntsysv*
 %dir %{_prefix}/var/lib/alternatives
 
 %changelog
+* Thu Feb 20 2020 Daniel Hams <daniel.hams@gmail.com> - 1.11-6
+- Rebuild due to libdicl upgrade to 0.1.19
+
 * Wed Jul 24 2019 Fedora Release Engineering <releng@fedoraproject.org> - 1.11-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
 

--- a/packages/elfutils/SPECS/elfutils.spec
+++ b/packages/elfutils/SPECS/elfutils.spec
@@ -4,7 +4,7 @@
 Name: elfutils
 Summary: A collection of utilities and DSOs to handle ELF files and DWARF data
 Version: 0.177
-%global baserelease 1
+%global baserelease 2
 URL: http://elfutils.org/
 %global source_url ftp://sourceware.org/pub/elfutils/%{version}/
 License: GPLv3+ and (GPLv2+ or LGPLv3+)
@@ -30,9 +30,9 @@ Patch11: elfutils.sgisuppressbuildid.patch
 Requires: elfutils-libelf%{depsuffix} = %{version}-%{release}
 Requires: elfutils-libs%{depsuffix} = %{version}-%{release}
 
-Requires: libdicl >= 0.1.15
+Requires: libdicl >= 0.1.19
 
-BuildRequires: libdicl-devel >= 0.1.15
+BuildRequires: libdicl-devel >= 0.1.19
 
 BuildRequires: gettext
 BuildRequires: bison >= 1.875
@@ -340,6 +340,9 @@ fi
 %endif
 
 %changelog
+* Thu Feb 20 2020 Daniel Hams <daniel.hams@gmail.com> - 0.177-2
+- Rebuild due to libdicl upgrade to 0.1.19
+
 * Wed Aug 14 2019 Mark Wielaard <mjw@fedoraproject.org> - 0.177-1
 - New upstream release.
   - elfclassify: New tool to analyze ELF objects.

--- a/packages/libdicl/SPECS/libdicl.spec
+++ b/packages/libdicl/SPECS/libdicl.spec
@@ -4,7 +4,7 @@
 
 Summary: Dans Irix Compatibility Library
 Name: libdicl
-Version: 0.1.17
+Version: 0.1.19
 Release: 1%{?dist}
 License: GPLv3+
 URL: https://github.com/danielhams/dicl
@@ -42,9 +42,9 @@ make install DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix} INSTALL='install -p'
 rm $RPM_BUILD_ROOT/%{_libdir}/libdicl-0.1.la
 
 %files
-#%{!?_licensedir:%global license %%doc}
-#%license COPYING
-#%doc README ChangeLog NEWS
+#%%{!?_licensedir:%%global license %%doc}
+#%%license COPYING
+#%%doc README ChangeLog NEWS
 %{_libdir}/libdicl-0.1.so.*
 
 %files devel
@@ -55,5 +55,8 @@ rm $RPM_BUILD_ROOT/%{_libdir}/libdicl-0.1.la
 
 
 %changelog
+* Thu Feb 20 2020 Daniel Hams <daniel.hams@gmail.com> - 0.1.19-1
+- Upgrade to 0.1.19 needed for pcre test passing / bug fixes.
+
 * Fri Nov 29 2019 Daniel Hams <daniel.hams@gmail.com> - 0.1.15
 - First build

--- a/packages/libtasn1/SPECS/libtasn1.spec
+++ b/packages/libtasn1/SPECS/libtasn1.spec
@@ -4,7 +4,7 @@
 Summary:	The ASN.1 library used in GNUTLS
 Name:		libtasn1
 Version:	4.14
-Release:	2%{?dist}
+Release:	3%{?dist}
 
 # The libtasn1 library is LGPLv2+, utilities are GPLv3+
 License:	GPLv3+ and LGPLv2+
@@ -20,9 +20,9 @@ BuildRequires:	gcc
 BuildRequires:	bison, pkgconfig, help2man
 BuildRequires:	autoconf, automake, libtool
 #BuildRequires:	valgrind-devel
-BuildRequires:  libdicl-devel
+BuildRequires:  libdicl-devel >= 0.1.19
 
-Requires:       libdicl
+Requires:       libdicl >= 0.1.19
 # Wildcard bundling exception https://fedorahosted.org/fpc/ticket/174
 Provides: bundled(gnulib) = 20130324
 
@@ -70,7 +70,7 @@ export CONFIG_SHELL="$SHELL"
 export SHELL=%{_bindir}/sh
 export SHELL_PATH="$SHELL"
 export CONFIG_SHELL="$SHELL"
-export CPPFLAGS="-I%{_includedir}/libdicl-0.1"
+export CPPFLAGS="-I%{_includedir}/libdicl-0.1 -DLIBDICL_NEED_GETOPT=1"
 export LDFLAGS="-ldicl-0.1 $RPM_LD_FLAGS"
 autoreconf -v -f --install
 %configure --disable-static --disable-silent-rules
@@ -111,6 +111,9 @@ make check
 
 
 %changelog
+* Thu Feb 20 2020 Daniel Hams <daniel.hams@gmail.com> - 4.14-3
+- Rebuild due to libdicl upgrade to 0.1.19
+
 * Thu Jul 25 2019 Fedora Release Engineering <releng@fedoraproject.org> - 4.14-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
 

--- a/packages/p11-kit/SPECS/p11-kit.spec
+++ b/packages/p11-kit/SPECS/p11-kit.spec
@@ -3,7 +3,7 @@
 
 # This spec file has been automatically updated
 Version:	0.23.16.1
-Release: 2%{?dist}
+Release:        3%{?dist}
 Name:           p11-kit
 Summary:        Library for loading and sharing PKCS#11 modules
 
@@ -24,8 +24,8 @@ BuildRequires:  libffi-devel
 # Work around for https://bugzilla.redhat.com/show_bug.cgi?id=1497147
 # Remove this once it is fixed
 #BuildRequires:  pkgconfig(glib-2.0)
-BuildRequires:  libdicl-devel
-Requires:       libdicl
+BuildRequires:  libdicl-devel >= 0.1.19
+Requires:       libdicl >= 0.1.19
 
 %description
 p11-kit provides a way to load and enumerate PKCS#11 modules, as well
@@ -37,7 +37,7 @@ such a way that they're discoverable.
 %package devel
 Summary:        Development files for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Requires:       libdicl-devel
+Requires:       libdicl-devel >= 0.1.19
 
 %description devel
 The %{name}-devel package contains libraries and header files for
@@ -47,6 +47,7 @@ developing applications that use %{name}.
 %package trust
 Summary:            System trust module from %{name}
 Requires:           %{name}%{?_isa} = %{version}-%{release}
+Requires:           libdicl-devel >= 0.1.19
 Requires(post):     %{_sbindir}/update-alternatives
 Requires(postun):   %{_sbindir}/update-alternatives
 Conflicts:          nss < 3.14.3-9
@@ -85,7 +86,7 @@ export CONFIG_SHELL="$SHELL"
 export SHELL=%{_bindir}/sh
 export SHELL_PATH="$SHELL"
 export CONFIG_SHELL="$SHELL"
-export CPPFLAGS="-I%{_includedir}/libdicl-0.1"
+export CPPFLAGS="-I%{_includedir}/libdicl-0.1 -DLIBDICL_NEED_GETOPT=1"
 export LIBS="-ldicl-0.1"
 # These paths are the source paths that  come from the plan here:
 # https://fedoraproject.org/wiki/Features/SharedSystemCertificates:SubTasks
@@ -170,6 +171,9 @@ fi
 
 
 %changelog
+* Thu Feb 20 2020 Daniel Hams <daniel.hams@gmail.com> - 0.23.16.1-3
+- Rebuild due to libdicl upgrade to 0.1.19
+
 * Thu Jul 25 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.23.16.1-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
 

--- a/packages/popt/SPECS/popt.spec
+++ b/packages/popt/SPECS/popt.spec
@@ -4,7 +4,7 @@
 Summary:	C library for parsing command line parameters
 Name:		popt
 Version:	1.16
-Release:	18%{?dist}
+Release:	19%{?dist}
 License:	MIT
 URL:		http://www.rpm5.org/
 Source:		http://www.rpm5.org/files/%{name}/%{name}-%{version}.tar.gz
@@ -15,8 +15,8 @@ Patch3:		popt-1.16-help.patch
 Patch4:		popt-1.16-nextarg-memleak.patch
 Patch5:		popt-1.16-glob-error.patch
 BuildRequires:	gcc gettext
-BuildRequires:  libdicl-devel
-Requires:       libdicl
+BuildRequires:  libdicl-devel >= 0.1.19
+Requires:       libdicl >= 0.1.19
 
 %description
 Popt is a C library for parsing command line parameters. Popt was
@@ -81,7 +81,7 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/popt.d
 %check
 make check
 
-#%ldconfig_scriptlets
+#%%ldconfig_scriptlets
 
 %files -f %{name}.lang
 %license COPYING
@@ -100,6 +100,9 @@ make check
 %{_libdir}/libpopt.a
 
 %changelog
+* Thu Feb 20 2020 Daniel Hams <daniel.hams@gmail.com> - 1.16-19
+- Rebuild due to libdicl upgrade to 0.1.19
+
 * Fri Jul 26 2019 Fedora Release Engineering <releng@fedoraproject.org> - 1.16-18
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
 

--- a/packages/rpm/SPECS/rpm.spec
+++ b/packages/rpm/SPECS/rpm.spec
@@ -21,7 +21,7 @@
 
 %global rpmver 4.15.0
 #global snapver rc1
-%global rel 6
+%global rel 7
 
 %global srcver %{version}%{?snapver:-%{snapver}}
 %global srcdir %{?snapver:testing}%{!?snapver:%{name}-%(echo %{version} | cut -d'.' -f1-2).x}
@@ -69,11 +69,8 @@ Patch2001: rpm.sgifixesldn32path.patch
 Patch2002: rpm.sgifixelfdeps.patch
 Patch2003: rpm.sgistriplibs.patch
 
-# Ugly work around - building RPM requires libdicl-0.1.16
-# But we need libdicl-0.1.17 for libtasn and pkcs11
-# So only force the build-time dep
-BuildRequires: libdicl-devel = 0.1.16
-Requires: libdicl >= 0.1.16
+BuildRequires: libdicl-devel >= 0.1.19
+Requires: libdicl >= 0.1.19
 
 # Ensure we have the sgug macros, too
 Requires: sgug-rpm-config
@@ -606,6 +603,9 @@ make check || (cat tests/rpmtests.log; exit 0)
 %doc doc/librpm/html/*
 
 %changelog
+* Thu Feb 20 2020 Daniel Hams <daniel.hams@gmail.com> - 4.15.0-7
+- Rebuild due to libdicl upgrade to 0.1.19
+
 * Wed Oct 23 2019 Peter Robinson <pbrobinson@fedoraproject.org> 4.15.0-6
 - Revert armv8 detection improvements
 


### PR DESCRIPTION
The upgrade to 0.1.19 of libdicl includes a fix so that no downgrade/upgrade dance is needed - all packages that depend on it can now be built against this newer version.

This pull request include the libdicl version change - but also a version bump and mandated minimum version of the things that _use_ libdicl.

The order to build and upgrade (do the install after each individual build) of these is:

libdicl
chkconfig (but only install the `alternatives` output RPM)
libtasn1
p11-kit
popt
elfutils
rpm

The upgrade in this pull request is needed for the merge of pcre.