### PR TITLE
Add the release / dependency management tools

### DIFF
--- a/packages/initial-sgug/SPECS/initial-sgug.spec
+++ b/packages/initial-sgug/SPECS/initial-sgug.spec
@@ -25,6 +25,7 @@ Provides: libcrypt.so
 Provides: librpcsvc.so
 Provides: libgssapi_krb5.so.2
 Provides: libsocket.so
+Provides: librt.so
 
 # X11 libraries that are used
 Provides: libX11.so.1

--- a/packages/initial-sgug/SPECS/initial-sgug.spec
+++ b/packages/initial-sgug/SPECS/initial-sgug.spec
@@ -2,7 +2,7 @@ Summary: Bootstrap vpkg for sgug
 Name: initial-sgug
 Epoch: 1
 Version: 0.2.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv3+
 
 Provides: /bin/sh
@@ -23,6 +23,8 @@ Provides: libgen.so
 Provides: libnsl.so
 Provides: libcrypt.so
 Provides: librpcsvc.so
+Provides: libgssapi_krb5.so.2
+Provides: libsocket.so
 
 # X11 libraries that are used
 Provides: libX11.so.1

--- a/packages/sgug-rpm-tools/SPECS/sgug-rpm-tools.spec
+++ b/packages/sgug-rpm-tools/SPECS/sgug-rpm-tools.spec
@@ -1,0 +1,37 @@
+Summary: SGUG RPM Tools
+Name: sgug-rpm-tools
+Version: 0.1.0
+Release: 1%{?dist}
+License: GPLv3+
+URL: https://github.com/sgidevnet/sgug-rpm-tools
+Source: https://github.com/sgidevnet/sgug-rpm-tools/releases/download/v%{version}/sgug-rpm-tools-%{version}.tar.gz
+
+BuildRequires: g++
+BuildRequires: automake, autoconf, libtool, pkgconfig
+BuildRequires: rpm-build, rpm-devel
+
+Requires: rpm, rpm-build
+
+%description
+Some utility programs to help with release / dependency management.
+
+%prep
+%setup -q
+
+%build
+%{configure}
+make %{?_smp_mflags}
+
+%check
+make check
+
+%install
+make install DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix} INSTALL='install -p'
+
+%files
+%{_bindir}/sgug_minimal_computer
+%{_bindir}/sgug_world_builder
+
+%changelog
+* Sun Mar 8 2020 Daniel Hams <daniel.hams@gmail.com> - 0.1.0
+- First build


### PR DESCRIPTION
This package includes two tools:

(1) sgug_world_rebuilder - generates a shell script that can be used to rebuild the sgug-rse world

(2) sgug_minimal_computer - works out what the minimal set of packages to install is  - and generates that minimal list, plus a list of which packages need to be removed to get there

These are part of the tooling used in building a sgug-rse release, so it is useful to have them as a package in sgug-rse too.