### PR TITLE
cmake, libuv, jsoncpp

### DIFF
--- a/packages/cmake/SOURCES/cmake.sgifixeslibuv.patch
+++ b/packages/cmake/SOURCES/cmake.sgifixeslibuv.patch
@@ -1,6 +1,6 @@
 diff -u -r -N cmake-3.17.2-orig/Modules/Platform/IRIX-GNU.cmake cmake-3.17.2/Modules/Platform/IRIX-GNU.cmake
 --- cmake-3.17.2-orig/Modules/Platform/IRIX-GNU.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ cmake-3.17.2/Modules/Platform/IRIX-GNU.cmake	2020-05-10 21:07:31.638429360 +0000
++++ cmake-3.17.2/Modules/Platform/IRIX-GNU.cmake	2020-05-12 18:15:19.077875480 +0000
 @@ -0,0 +1,8 @@
 +# This module is shared by multiple languages; use include blocker.
 +if(__IRIX_COMPILER_GNU)
@@ -12,9 +12,10 @@ diff -u -r -N cmake-3.17.2-orig/Modules/Platform/IRIX-GNU.cmake cmake-3.17.2/Mod
 +endmacro()
 diff -u -r -N cmake-3.17.2-orig/Modules/Platform/IRIX.cmake cmake-3.17.2/Modules/Platform/IRIX.cmake
 --- cmake-3.17.2-orig/Modules/Platform/IRIX.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ cmake-3.17.2/Modules/Platform/IRIX.cmake	2020-05-10 21:07:31.639723680 +0000
-@@ -0,0 +1,28 @@
++++ cmake-3.17.2/Modules/Platform/IRIX.cmake	2020-05-12 18:15:19.079508280 +0000
+@@ -0,0 +1,29 @@
 +set(CMAKE_DL_LIBS "dl")
++set(CMAKE_INSTALL_LIBDIR "lib32")
 +set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
 +set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG_SEP ":")
 +#set(CMAKE_SHARED_LIBRARY_RPATH_ORIGIN_TOKEN "\$ORIGIN")
@@ -44,7 +45,7 @@ diff -u -r -N cmake-3.17.2-orig/Modules/Platform/IRIX.cmake cmake-3.17.2/Modules
 +set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB32_PATHS TRUE)
 diff -u -r -N cmake-3.17.2-orig/Modules/Platform/IRIX64-GNU.cmake cmake-3.17.2/Modules/Platform/IRIX64-GNU.cmake
 --- cmake-3.17.2-orig/Modules/Platform/IRIX64-GNU.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ cmake-3.17.2/Modules/Platform/IRIX64-GNU.cmake	2020-05-10 21:07:31.640856240 +0000
++++ cmake-3.17.2/Modules/Platform/IRIX64-GNU.cmake	2020-05-12 18:15:19.080986120 +0000
 @@ -0,0 +1,8 @@
 +# This module is shared by multiple languages; use include blocker.
 +if(__IRIX_COMPILER_GNU)
@@ -56,9 +57,10 @@ diff -u -r -N cmake-3.17.2-orig/Modules/Platform/IRIX64-GNU.cmake cmake-3.17.2/M
 +endmacro()
 diff -u -r -N cmake-3.17.2-orig/Modules/Platform/IRIX64.cmake cmake-3.17.2/Modules/Platform/IRIX64.cmake
 --- cmake-3.17.2-orig/Modules/Platform/IRIX64.cmake	1970-01-01 00:00:00.000000000 +0000
-+++ cmake-3.17.2/Modules/Platform/IRIX64.cmake	2020-05-10 21:07:31.642015600 +0000
-@@ -0,0 +1,28 @@
++++ cmake-3.17.2/Modules/Platform/IRIX64.cmake	2020-05-12 18:15:19.082310760 +0000
+@@ -0,0 +1,29 @@
 +set(CMAKE_DL_LIBS "dl")
++set(CMAKE_INSTALL_LIBDIR "lib32")
 +set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
 +set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG_SEP ":")
 +#set(CMAKE_SHARED_LIBRARY_RPATH_ORIGIN_TOKEN "\$ORIGIN")
@@ -88,7 +90,7 @@ diff -u -r -N cmake-3.17.2-orig/Modules/Platform/IRIX64.cmake cmake-3.17.2/Modul
 +set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB32_PATHS TRUE)
 diff -u -r -N cmake-3.17.2-orig/Source/CTest/cmProcess.cxx cmake-3.17.2/Source/CTest/cmProcess.cxx
 --- cmake-3.17.2-orig/Source/CTest/cmProcess.cxx	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Source/CTest/cmProcess.cxx	2020-05-10 21:07:32.149603320 +0000
++++ cmake-3.17.2/Source/CTest/cmProcess.cxx	2020-05-12 18:15:19.084400920 +0000
 @@ -106,7 +106,7 @@
    options.stdio_count = 3; // in, out and err
    options.exit_cb = &cmProcess::OnExitCB;
@@ -100,7 +102,7 @@ diff -u -r -N cmake-3.17.2-orig/Source/CTest/cmProcess.cxx cmake-3.17.2/Source/C
      cpumask.resize(static_cast<size_t>(uv_cpumask_size()), 0);
 diff -u -r -N cmake-3.17.2-orig/Source/cmSystemTools.cxx cmake-3.17.2/Source/cmSystemTools.cxx
 --- cmake-3.17.2-orig/Source/cmSystemTools.cxx	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Source/cmSystemTools.cxx	2020-05-10 21:07:32.264552360 +0000
++++ cmake-3.17.2/Source/cmSystemTools.cxx	2020-05-12 18:15:21.059611400 +0000
 @@ -1885,7 +1885,9 @@
  
    // Try using a real random source.
@@ -113,7 +115,7 @@ diff -u -r -N cmake-3.17.2-orig/Source/cmSystemTools.cxx cmake-3.17.2/Source/cmS
        fin.gcount() == sizeof(seed)) {
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c cmake-3.17.2/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c
 --- cmake-3.17.2-orig/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c	2020-05-10 21:07:32.269141800 +0000
++++ cmake-3.17.2/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c	2020-05-12 18:15:21.064553800 +0000
 @@ -2465,7 +2465,7 @@
  tree_current_lstat(struct tree *t)
  {
@@ -125,7 +127,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibarchive/libarchive/archive_read_d
  		    AT_SYMLINK_NOFOLLOW) != 0)
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibarchive/libarchive/filter_fork_posix.c cmake-3.17.2/Utilities/cmlibarchive/libarchive/filter_fork_posix.c
 --- cmake-3.17.2-orig/Utilities/cmlibarchive/libarchive/filter_fork_posix.c	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibarchive/libarchive/filter_fork_posix.c	2020-05-10 21:07:32.270949480 +0000
++++ cmake-3.17.2/Utilities/cmlibarchive/libarchive/filter_fork_posix.c	2020-05-12 18:15:21.066373640 +0000
 @@ -77,7 +77,7 @@
  {
  	pid_t child;
@@ -155,7 +157,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibarchive/libarchive/filter_fork_po
  	posix_spawn_file_actions_destroy(&actions);
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/CMakeLists.txt cmake-3.17.2/Utilities/cmlibuv/CMakeLists.txt
 --- cmake-3.17.2-orig/Utilities/cmlibuv/CMakeLists.txt	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/CMakeLists.txt	2020-05-10 21:07:32.272606840 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/CMakeLists.txt	2020-05-12 18:15:21.067964280 +0000
 @@ -336,6 +336,23 @@
      )
  endif()
@@ -182,7 +184,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/CMakeLists.txt cmake-3.17.2/Ut
    ${KWSYS_HEADER_ROOT}
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/include/uv/unix.h cmake-3.17.2/Utilities/cmlibuv/include/uv/unix.h
 --- cmake-3.17.2-orig/Utilities/cmlibuv/include/uv/unix.h	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/include/uv/unix.h	2020-05-10 21:07:32.274521480 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/include/uv/unix.h	2020-05-12 18:15:21.069904920 +0000
 @@ -70,6 +70,8 @@
        defined(__MSYS__)   || \
        defined(__GNU__)
@@ -194,7 +196,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/include/uv/unix.h cmake-3.17.2
  #endif
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/include/uv.h cmake-3.17.2/Utilities/cmlibuv/include/uv.h
 --- cmake-3.17.2-orig/Utilities/cmlibuv/include/uv.h	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/include/uv.h	2020-05-10 21:07:32.277712920 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/include/uv.h	2020-05-12 18:15:21.073418360 +0000
 @@ -24,6 +24,31 @@
  #ifndef UV_H
  #define UV_H
@@ -229,7 +231,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/include/uv.h cmake-3.17.2/Util
  
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/core.c cmake-3.17.2/Utilities/cmlibuv/src/unix/core.c
 --- cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/core.c	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/src/unix/core.c	2020-05-10 21:07:32.280602600 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/src/unix/core.c	2020-05-12 18:15:21.076952200 +0000
 @@ -587,7 +587,7 @@
  }
  
@@ -272,7 +274,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/core.c cmake-3.17.2/U
      if (cmsg->cmsg_type == SCM_RIGHTS)
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/fs.c cmake-3.17.2/Utilities/cmlibuv/src/unix/fs.c
 --- cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/fs.c	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/src/unix/fs.c	2020-05-10 21:07:32.283477640 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/src/unix/fs.c	2020-05-12 18:17:20.981414120 +0000
 @@ -358,7 +358,7 @@
  }
  
@@ -282,9 +284,22 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/fs.c cmake-3.17.2/Uti
  #define UV_CONST_DIRENT uv__dirent_t
  #else
  #define UV_CONST_DIRENT const uv__dirent_t
+@@ -575,8 +575,12 @@
+ #else
+   ssize_t len;
+ 
++#if defined(__sgi)
++  buf = uv__malloc(PATH_MAX + 1);
++#else
+   len = uv__fs_pathmax_size(req->path);
+   buf = uv__malloc(len + 1);
++#endif
+ 
+   if (buf == NULL) {
+     errno = ENOMEM;
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/internal.h cmake-3.17.2/Utilities/cmlibuv/src/unix/internal.h
 --- cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/internal.h	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/src/unix/internal.h	2020-05-10 21:07:32.285102520 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/src/unix/internal.h	2020-05-12 18:15:21.081513640 +0000
 @@ -195,7 +195,11 @@
  int uv__close_nocheckstdio(int fd);
  int uv__close_nocancel(int fd);
@@ -316,7 +331,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/internal.h cmake-3.17
  #endif /* UV_UNIX_INTERNAL_H_ */
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/irix.c cmake-3.17.2/Utilities/cmlibuv/src/unix/irix.c
 --- cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/irix.c	1970-01-01 00:00:00.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/src/unix/irix.c	2020-05-10 21:07:32.286428920 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/src/unix/irix.c	2020-05-12 18:15:21.082977320 +0000
 @@ -0,0 +1,45 @@
 +#include "uv.h"
 +#include "internal.h"
@@ -365,7 +380,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/irix.c cmake-3.17.2/U
 +}
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/posix-hrtime.c cmake-3.17.2/Utilities/cmlibuv/src/unix/posix-hrtime.c
 --- cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/posix-hrtime.c	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/src/unix/posix-hrtime.c	2020-05-10 21:07:32.287521160 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/src/unix/posix-hrtime.c	2020-05-12 18:15:21.084081880 +0000
 @@ -67,7 +67,11 @@
  
  uint64_t uv__hrtime(uv_clocktype_t type) {
@@ -380,7 +395,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/posix-hrtime.c cmake-
  
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/stream.c cmake-3.17.2/Utilities/cmlibuv/src/unix/stream.c
 --- cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/stream.c	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/src/unix/stream.c	2020-05-10 21:15:41.011033040 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/src/unix/stream.c	2020-05-12 18:15:21.087179240 +0000
 @@ -840,7 +840,11 @@
  
    if (req->send_handle) {
@@ -471,7 +486,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/stream.c cmake-3.17.2
          nread = uv__recvmsg(uv__stream_fd(stream), &msg, 0);
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/thread.c cmake-3.17.2/Utilities/cmlibuv/src/unix/thread.c
 --- cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/thread.c	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/src/unix/thread.c	2020-05-10 21:07:32.292494520 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/src/unix/thread.c	2020-05-12 18:17:49.497670640 +0000
 @@ -700,7 +700,7 @@
    if (err)
      return UV__ERR(err);
@@ -481,9 +496,27 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/thread.c cmake-3.17.2
    err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
    if (err)
      goto error2;
+@@ -778,7 +778,7 @@
+ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
+   int r;
+   struct timespec ts;
+-#if defined(__MVS__)
++#if defined(__MVS__) || defined(__sgi)
+   struct timeval tv;
+ #endif
+ 
+@@ -787,7 +787,7 @@
+   ts.tv_nsec = timeout % NANOSEC;
+   r = pthread_cond_timedwait_relative_np(cond, mutex, &ts);
+ #else
+-#if defined(__MVS__)
++#if defined(__MVS__) || defined(__sgi)
+   if (gettimeofday(&tv, NULL))
+     abort();
+   timeout += tv.tv_sec * NANOSEC + tv.tv_usec * 1e3;
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/tty.c cmake-3.17.2/Utilities/cmlibuv/src/unix/tty.c
 --- cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/tty.c	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/src/unix/tty.c	2020-05-10 21:07:32.293955560 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/src/unix/tty.c	2020-05-12 18:18:09.978706160 +0000
 @@ -200,7 +200,7 @@
  static void uv__tty_make_raw(struct termios* tio) {
    assert(tio != NULL);
@@ -493,9 +526,18 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/tty.c cmake-3.17.2/Ut
    /*
     * This implementation of cfmakeraw for Solaris and derivatives is taken from
     * http://www.perkin.org.uk/posts/solaris-portability-cfmakeraw.html.
+@@ -321,7 +321,7 @@
+       return UV_UDP;
+ 
+   if (type == SOCK_STREAM) {
+-#if defined(_AIX) || defined(__DragonFly__)
++#if defined(_AIX) || defined(__DragonFly__) || defined(__sgi)
+     /* on AIX/DragonFly the getsockname call returns an empty sa structure
+      * for sockets of type AF_UNIX.  For all other types it will
+      * return a properly filled in structure.
 diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/udp.c cmake-3.17.2/Utilities/cmlibuv/src/unix/udp.c
 --- cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/udp.c	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/Utilities/cmlibuv/src/unix/udp.c	2020-05-10 21:15:59.362544000 +0000
++++ cmake-3.17.2/Utilities/cmlibuv/src/unix/udp.c	2020-05-12 18:15:21.093468520 +0000
 @@ -151,7 +151,11 @@
  
  static void uv__udp_recvmsg(uv_udp_t* handle) {
@@ -581,7 +623,7 @@ diff -u -r -N cmake-3.17.2-orig/Utilities/cmlibuv/src/unix/udp.c cmake-3.17.2/Ut
    if (size == -1) {
 diff -u -r -N cmake-3.17.2-orig/bootstrap cmake-3.17.2/bootstrap
 --- cmake-3.17.2-orig/bootstrap	2020-04-28 15:23:06.000000000 +0000
-+++ cmake-3.17.2/bootstrap	2020-05-10 21:07:32.299428520 +0000
++++ cmake-3.17.2/bootstrap	2020-05-12 18:15:21.096848840 +0000
 @@ -568,6 +568,7 @@
      src/unix/cmake-bootstrap.c \
      src/unix/core.c \

--- a/packages/cmake/SPECS/cmake.spec
+++ b/packages/cmake/SPECS/cmake.spec
@@ -68,7 +68,7 @@
 
 Name:           %{orig_name}%{?name_suffix}
 Version:        %{major_version}.%{minor_version}.2
-Release:        1%{?relsuf}%{?dist}
+Release:        2%{?relsuf}%{?dist}
 Summary:        Cross-platform make system
 
 # most sources are BSD
@@ -527,6 +527,9 @@ mv -f Modules/FindLibArchive.disabled Modules/FindLibArchive.cmake
 
 
 %changelog
+* Tue May 12 2020 Daniel Hams <daniel.hams@gmail.com> - 3.17.2-2
+- Fix lib install dir to be lib32, pull bug fixes + stability fixes from sgug libuv github
+
 * Sat May 9 2020 Daniel Hams <daniel.hams@gmail.com> - 3.17.2-1
 - Import from fedora
 

--- a/packages/jsoncpp/SPECS/jsoncpp.spec
+++ b/packages/jsoncpp/SPECS/jsoncpp.spec
@@ -11,7 +11,7 @@
 
 Name:           jsoncpp
 Version:        1.9.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        JSON library implemented in C++
 
 License:        Public Domain or MIT
@@ -20,7 +20,8 @@ Source0:        %{url}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 Patch0000:      %{name}-1.9.1-fix_version.patch
 
-BuildRequires:  cmake >= 3.1
+# Needs this version to do lib install in lib32
+BuildRequires:  cmake >= 3.17.2-2
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  python3-devel
@@ -69,14 +70,12 @@ export PREV_WD=`pwd`
 export CC=mips-sgi-irix6.5-gcc
 export CXX=mips-sgi-irix6.5-g++
 cd %{_target_platform}
-export CMAKE_INSTALL_LIBDIR=%{_lib}
 %cmake -DBUILD_STATIC_LIBS=OFF                \
        -DJSONCPP_WITH_WARNING_AS_ERROR=OFF    \
        -DJSONCPP_WITH_PKGCONFIG_SUPPORT=ON    \
        -DJSONCPP_WITH_CMAKE_PACKAGE=ON        \
        -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF \
        -DPYTHON_EXECUTABLE="%{__python3}"     \
-       -DCMAKE_INSTALL_LIBDIR=%{_lib}         \
        ..
 cd $PREV_WD
 %make_build -C %{_target_platform}
@@ -137,6 +136,9 @@ chmod a+x %{buildroot}%{_libdir}/*.so.*
 
 
 %changelog
+* Tue May 12 2020 Daniel Hams <daniel.hams@gmail.com> - 1.9.1-2
+- cmake now default installs into lib32
+
 * Sun May 10 2020 Daniel Hams <daniel.hams@gmail.com> - 1.9.1-1
 - Bring into wip
 

--- a/packages/libuv/SOURCES/libuv.sgifixes.patch
+++ b/packages/libuv/SOURCES/libuv.sgifixes.patch
@@ -1,6 +1,6 @@
 diff -u -r -N libuv-v1.37.0-orig/Makefile.am libuv-v1.37.0/Makefile.am
 --- libuv-v1.37.0-orig/Makefile.am	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/Makefile.am	2020-05-09 19:42:58.001508600 +0000
++++ libuv-v1.37.0/Makefile.am	2020-05-12 16:53:56.813839640 +0000
 @@ -131,7 +131,7 @@
  
  TESTS = test/run-tests
@@ -39,7 +39,7 @@ diff -u -r -N libuv-v1.37.0-orig/Makefile.am libuv-v1.37.0/Makefile.am
  uvinclude_HEADERS += include/uv/linux.h
 diff -u -r -N libuv-v1.37.0-orig/configure.ac libuv-v1.37.0/configure.ac
 --- libuv-v1.37.0-orig/configure.ac	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/configure.ac	2020-05-09 19:42:58.002769640 +0000
++++ libuv-v1.37.0/configure.ac	2020-05-12 16:53:56.815012040 +0000
 @@ -56,6 +56,7 @@
  AM_CONDITIONAL([FREEBSD],  [AS_CASE([$host_os],[*freebsd*],     [true], [false])])
  AM_CONDITIONAL([HAIKU],    [AS_CASE([$host_os],[haiku],         [true], [false])])
@@ -50,7 +50,7 @@ diff -u -r -N libuv-v1.37.0-orig/configure.ac libuv-v1.37.0/configure.ac
  AM_CONDITIONAL([NETBSD],   [AS_CASE([$host_os],[netbsd*],       [true], [false])])
 diff -u -r -N libuv-v1.37.0-orig/include/uv/unix.h libuv-v1.37.0/include/uv/unix.h
 --- libuv-v1.37.0-orig/include/uv/unix.h	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/include/uv/unix.h	2020-05-09 19:42:58.004606440 +0000
++++ libuv-v1.37.0/include/uv/unix.h	2020-05-12 16:53:56.816759240 +0000
 @@ -67,6 +67,8 @@
        defined(__MSYS__)   || \
        defined(__GNU__)
@@ -62,7 +62,7 @@ diff -u -r -N libuv-v1.37.0-orig/include/uv/unix.h libuv-v1.37.0/include/uv/unix
  #endif
 diff -u -r -N libuv-v1.37.0-orig/src/unix/core.c libuv-v1.37.0/src/unix/core.c
 --- libuv-v1.37.0-orig/src/unix/core.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/src/unix/core.c	2020-05-09 19:42:58.007695080 +0000
++++ libuv-v1.37.0/src/unix/core.c	2020-05-12 16:53:56.819867000 +0000
 @@ -18,6 +18,29 @@
   * IN THE SOFTWARE.
   */
@@ -135,7 +135,7 @@ diff -u -r -N libuv-v1.37.0-orig/src/unix/core.c libuv-v1.37.0/src/unix/core.c
      if (cmsg->cmsg_type == SCM_RIGHTS)
 diff -u -r -N libuv-v1.37.0-orig/src/unix/fs.c libuv-v1.37.0/src/unix/fs.c
 --- libuv-v1.37.0-orig/src/unix/fs.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/src/unix/fs.c	2020-05-09 19:42:58.011057160 +0000
++++ libuv-v1.37.0/src/unix/fs.c	2020-05-12 16:55:11.502453840 +0000
 @@ -504,7 +504,7 @@
  }
  
@@ -177,9 +177,22 @@ diff -u -r -N libuv-v1.37.0-orig/src/unix/fs.c libuv-v1.37.0/src/unix/fs.c
    stat_fs->f_files = buf.f_files;
    stat_fs->f_ffree = buf.f_ffree;
    req->ptr = stat_fs;
+@@ -741,8 +752,12 @@
+ #else
+   ssize_t len;
+ 
++#if defined(__sgi)
++  buf = uv__malloc(PATH_MAX + 1);
++#else
+   len = uv__fs_pathmax_size(req->path);
+   buf = uv__malloc(len + 1);
++#endif
+ 
+   if (buf == NULL) {
+     errno = ENOMEM;
 diff -u -r -N libuv-v1.37.0-orig/src/unix/internal.h libuv-v1.37.0/src/unix/internal.h
 --- libuv-v1.37.0-orig/src/unix/internal.h	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/src/unix/internal.h	2020-05-09 19:42:58.012837800 +0000
++++ libuv-v1.37.0/src/unix/internal.h	2020-05-12 16:53:56.825402440 +0000
 @@ -195,7 +195,11 @@
  int uv__close_nocheckstdio(int fd);
  int uv__close_nocancel(int fd);
@@ -212,7 +225,7 @@ diff -u -r -N libuv-v1.37.0-orig/src/unix/internal.h libuv-v1.37.0/src/unix/inte
      defined(__FreeBSD__)          ||                                      \
 diff -u -r -N libuv-v1.37.0-orig/src/unix/irix-common.c libuv-v1.37.0/src/unix/irix-common.c
 --- libuv-v1.37.0-orig/src/unix/irix-common.c	1970-01-01 00:00:00.000000000 +0000
-+++ libuv-v1.37.0/src/unix/irix-common.c	2020-05-09 19:42:58.014868360 +0000
++++ libuv-v1.37.0/src/unix/irix-common.c	2020-05-12 16:53:56.827414840 +0000
 @@ -0,0 +1,462 @@
 +/* Copyright libuv project contributors. All rights reserved.
 + *
@@ -678,7 +691,7 @@ diff -u -r -N libuv-v1.37.0-orig/src/unix/irix-common.c libuv-v1.37.0/src/unix/i
 +}
 diff -u -r -N libuv-v1.37.0-orig/src/unix/posix-hrtime.c libuv-v1.37.0/src/unix/posix-hrtime.c
 --- libuv-v1.37.0-orig/src/unix/posix-hrtime.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/src/unix/posix-hrtime.c	2020-05-09 19:42:58.016343240 +0000
++++ libuv-v1.37.0/src/unix/posix-hrtime.c	2020-05-12 16:53:56.828877000 +0000
 @@ -30,6 +30,10 @@
  
  uint64_t uv__hrtime(uv_clocktype_t type) {
@@ -692,7 +705,7 @@ diff -u -r -N libuv-v1.37.0-orig/src/unix/posix-hrtime.c libuv-v1.37.0/src/unix/
  }
 diff -u -r -N libuv-v1.37.0-orig/src/unix/stream.c libuv-v1.37.0/src/unix/stream.c
 --- libuv-v1.37.0-orig/src/unix/stream.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/src/unix/stream.c	2020-05-09 19:43:14.768675360 +0000
++++ libuv-v1.37.0/src/unix/stream.c	2020-05-12 16:53:56.832219800 +0000
 @@ -19,6 +19,29 @@
   * IN THE SOFTWARE.
   */
@@ -801,7 +814,7 @@ diff -u -r -N libuv-v1.37.0-orig/src/unix/stream.c libuv-v1.37.0/src/unix/stream
          nread = uv__recvmsg(uv__stream_fd(stream), &msg, 0);
 diff -u -r -N libuv-v1.37.0-orig/src/unix/thread.c libuv-v1.37.0/src/unix/thread.c
 --- libuv-v1.37.0-orig/src/unix/thread.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/src/unix/thread.c	2020-05-09 19:42:58.021607080 +0000
++++ libuv-v1.37.0/src/unix/thread.c	2020-05-12 16:55:17.456901120 +0000
 @@ -241,6 +241,8 @@
  #ifdef PTHREAD_STACK_MIN
      if (stack_size < PTHREAD_STACK_MIN)
@@ -820,9 +833,27 @@ diff -u -r -N libuv-v1.37.0-orig/src/unix/thread.c libuv-v1.37.0/src/unix/thread
    err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
    if (err)
      goto error2;
+@@ -786,7 +788,7 @@
+ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
+   int r;
+   struct timespec ts;
+-#if defined(__MVS__)
++#if defined(__MVS__) || defined(__sgi)
+   struct timeval tv;
+ #endif
+ 
+@@ -795,7 +797,7 @@
+   ts.tv_nsec = timeout % NANOSEC;
+   r = pthread_cond_timedwait_relative_np(cond, mutex, &ts);
+ #else
+-#if defined(__MVS__)
++#if defined(__MVS__) || defined(__sgi)
+   if (gettimeofday(&tv, NULL))
+     abort();
+   timeout += tv.tv_sec * NANOSEC + tv.tv_usec * 1e3;
 diff -u -r -N libuv-v1.37.0-orig/src/unix/tty.c libuv-v1.37.0/src/unix/tty.c
 --- libuv-v1.37.0-orig/src/unix/tty.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/src/unix/tty.c	2020-05-09 19:42:58.023295800 +0000
++++ libuv-v1.37.0/src/unix/tty.c	2020-05-12 16:55:02.256048160 +0000
 @@ -231,7 +231,7 @@
  static void uv__tty_make_raw(struct termios* tio) {
    assert(tio != NULL);
@@ -832,9 +863,18 @@ diff -u -r -N libuv-v1.37.0-orig/src/unix/tty.c libuv-v1.37.0/src/unix/tty.c
    /*
     * This implementation of cfmakeraw for Solaris and derivatives is taken from
     * http://www.perkin.org.uk/posts/solaris-portability-cfmakeraw.html.
+@@ -352,7 +352,7 @@
+       return UV_UDP;
+ 
+   if (type == SOCK_STREAM) {
+-#if defined(_AIX) || defined(__DragonFly__)
++#if defined(_AIX) || defined(__DragonFly__) || defined(__sgi)
+     /* on AIX/DragonFly the getsockname call returns an empty sa structure
+      * for sockets of type AF_UNIX.  For all other types it will
+      * return a properly filled in structure.
 diff -u -r -N libuv-v1.37.0-orig/src/unix/udp.c libuv-v1.37.0/src/unix/udp.c
 --- libuv-v1.37.0-orig/src/unix/udp.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/src/unix/udp.c	2020-05-09 19:42:58.026254600 +0000
++++ libuv-v1.37.0/src/unix/udp.c	2020-05-12 16:53:56.839168440 +0000
 @@ -19,6 +19,29 @@
   * IN THE SOFTWARE.
   */
@@ -933,7 +973,7 @@ diff -u -r -N libuv-v1.37.0-orig/src/unix/udp.c libuv-v1.37.0/src/unix/udp.c
    struct sockaddr_in* mcast_addr4;
 diff -u -r -N libuv-v1.37.0-orig/test/test-ipc.c libuv-v1.37.0/test/test-ipc.c
 --- libuv-v1.37.0-orig/test/test-ipc.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/test/test-ipc.c	2020-05-09 19:42:58.028512600 +0000
++++ libuv-v1.37.0/test/test-ipc.c	2020-05-12 16:53:56.841950040 +0000
 @@ -19,6 +19,10 @@
   * IN THE SOFTWARE.
   */
@@ -947,7 +987,7 @@ diff -u -r -N libuv-v1.37.0-orig/test/test-ipc.c libuv-v1.37.0/test/test-ipc.c
  
 diff -u -r -N libuv-v1.37.0-orig/test/test-pipe-sendmsg.c libuv-v1.37.0/test/test-pipe-sendmsg.c
 --- libuv-v1.37.0-orig/test/test-pipe-sendmsg.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/test/test-pipe-sendmsg.c	2020-05-09 19:42:58.030371560 +0000
++++ libuv-v1.37.0/test/test-pipe-sendmsg.c	2020-05-12 16:53:56.843942360 +0000
 @@ -19,6 +19,29 @@
   * IN THE SOFTWARE.
   */
@@ -1027,9 +1067,21 @@ diff -u -r -N libuv-v1.37.0-orig/test/test-pipe-sendmsg.c libuv-v1.37.0/test/tes
    while (r == -1 && errno == EINTR);
    ASSERT(r == 1);
  
+diff -u -r -N libuv-v1.37.0-orig/test/test-poll.c libuv-v1.37.0/test/test-poll.c
+--- libuv-v1.37.0-orig/test/test-poll.c	2020-04-19 17:15:57.000000000 +0000
++++ libuv-v1.37.0/test/test-poll.c	2020-05-12 16:55:28.413420440 +0000
+@@ -622,7 +622,7 @@
+ #if !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__sun) && \
+     !defined(_AIX) && !defined(__MVS__) && !defined(__FreeBSD_kernel__) && \
+     !defined(__OpenBSD__) && !defined(__CYGWIN__) && !defined(__MSYS__) && \
+-    !defined(__NetBSD__)
++    !defined(__NetBSD__) && !defined(__sgi)
+   uv_poll_t poll_handle;
+   int fd;
+ 
 diff -u -r -N libuv-v1.37.0-orig/test/test-process-title-threadsafe.c libuv-v1.37.0/test/test-process-title-threadsafe.c
 --- libuv-v1.37.0-orig/test/test-process-title-threadsafe.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/test/test-process-title-threadsafe.c	2020-05-09 19:42:58.031897160 +0000
++++ libuv-v1.37.0/test/test-process-title-threadsafe.c	2020-05-12 16:53:56.845522200 +0000
 @@ -19,6 +19,9 @@
  * IN THE SOFTWARE.
  */
@@ -1042,7 +1094,7 @@ diff -u -r -N libuv-v1.37.0-orig/test/test-process-title-threadsafe.c libuv-v1.3
  #include "task.h"
 diff -u -r -N libuv-v1.37.0-orig/test/test-spawn.c libuv-v1.37.0/test/test-spawn.c
 --- libuv-v1.37.0-orig/test/test-spawn.c	2020-04-19 17:15:57.000000000 +0000
-+++ libuv-v1.37.0/test/test-spawn.c	2020-05-09 19:42:58.035180520 +0000
++++ libuv-v1.37.0/test/test-spawn.c	2020-05-12 16:53:56.848855480 +0000
 @@ -1392,8 +1392,13 @@
    ASSERT(pw != NULL);
    options.uid = pw->pw_uid;

--- a/packages/libuv/SPECS/libuv.spec
+++ b/packages/libuv/SPECS/libuv.spec
@@ -1,7 +1,7 @@
 Name:           libuv
 Epoch:          1
 Version:        1.37.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Platform layer for node.js
 
 # the licensing breakdown is described in detail in the LICENSE file
@@ -86,6 +86,9 @@ install -Dm0755 -t %{buildroot}%{_libdir}/libuv/ %{SOURCE3}
 %{_libdir}/%{name}.a
 
 %changelog
+* Tue May 12 2020 Daniel Hams <daniel.hams@gmail.com> - 1.37.0-2
+- Pull bug fixes + stability fixes from sgug libuv github
+
 * Sat May 9 2020 Daniel Hams <daniel.hams@gmail.com> - 1.37.0-1
 - Bring into wip
 


### PR DESCRIPTION
Fix up the cmake install libdir to be lib32 and pull some sgug libuv fixes + stability tweaks.
jsoncpp now doesn't have the library directory work around.