### PR TITLE
More fixes for this POS (Needs review. This PR is probably crap)

### DIFF
--- a/packages/docbook-style-dsssl/SPECS/docbook-style-dsssl.spec
+++ b/packages/docbook-style-dsssl/SPECS/docbook-style-dsssl.spec
@@ -6,10 +6,10 @@ Summary: Norman Walsh's modular stylesheets for DocBook
 
 License: DMIT
 URL: http://docbook.sourceforge.net/
-BuildRequires: perl-generators
+#BuildRequires: perl-generators
 
 Requires: docbook-dtds
-Requires: openjade
+#Requires: openjade
 Requires: sgml-common
 Requires(post): sgml-common
 Requires(preun): sgml-common
@@ -33,32 +33,32 @@ cp %{SOURCE1} Makefile
 
 %install
 DESTDIR=$RPM_BUILD_ROOT
-make install BINDIR=$DESTDIR/usr/bin DESTDIR=$DESTDIR/usr/share/sgml/docbook/dsssl-stylesheets-%{version} MANDIR=$DESTDIR%{_mandir}
+make install BINDIR=$DESTDIR/usr/sgug/bin DESTDIR=$DESTDIR/usr/sgug/share/sgml/docbook/dsssl-stylesheets-%{version} MANDIR=$DESTDIR%{_mandir}
 cd ..
-ln -s dsssl-stylesheets-%{version} $DESTDIR/usr/share/sgml/docbook/dsssl-stylesheets
+ln -s dsssl-stylesheets-%{version} $DESTDIR/usr/sgug/share/sgml/docbook/dsssl-stylesheets
 
 %files
 %doc BUGS README ChangeLog WhatsNew
-/usr/bin/collateindex.pl
+/usr/sgug/bin/collateindex.pl
 %{_mandir}/man1/collateindex.pl.1*
-/usr/share/sgml/docbook/dsssl-stylesheets-%{version}
-/usr/share/sgml/docbook/dsssl-stylesheets
+/usr/sgug/share/sgml/docbook/dsssl-stylesheets-%{version}
+/usr/sgug/share/sgml/docbook/dsssl-stylesheets
 
 
 %post
-for centralized in /etc/sgml/*-docbook-*.cat
+for centralized in /usr/sgug/etc/sgml/*-docbook-*.cat
 do
-  /usr/bin/install-catalog --add $centralized \
-    /usr/share/sgml/docbook/dsssl-stylesheets-%{version}/catalog \
+  /usr/sgug/bin/install-catalog --add $centralized \
+    /usr/sgug/share/sgml/docbook/dsssl-stylesheets-%{version}/catalog \
     > /dev/null 2>/dev/null
 done
 
 
 %preun
 if [ "$1" = "0" ]; then
-  for centralized in /etc/sgml/*-docbook-*.cat
+  for centralized in /usr/sgug/etc/sgml/*-docbook-*.cat
   do
-    /usr/bin/install-catalog --remove $centralized /usr/share/sgml/docbook/dsssl-stylesheets-%{version}/catalog > /dev/null 2>/dev/null
+    /usr/sgug/bin/install-catalog --remove $centralized /usr/sgug/share/sgml/docbook/dsssl-stylesheets-%{version}/catalog > /dev/null 2>/dev/null
   done
 fi
 exit 0


### PR DESCRIPTION
I'm thoroughly confused by how this thing uses paths. 

It seems that there's deep bits that insist upon writing outside /usr/sgug. 

And there's other bits that insist perl lives in /usr/bin/perl .

Assistance would be appreciated. I'm tagging a bunch of reviewers as I don't know which of you knows perl best.