### PR TITLE
ICU4C: Provide filtered ICU dat file

### DIFF
--- a/packages/icu/SOURCES/exclude-burmese.patch
+++ b/packages/icu/SOURCES/exclude-burmese.patch
@@ -1,8 +1,10 @@
 --- icu.orig/source/data/BUILDRULES.py       2020-05-24 19:06:58.842238240 +0000
 +++ icu/source/data/BUILDRULES.py            2020-05-24 17:38:47.929485280 +0000
-@@ -221,7 +221,6 @@
+@@ -220,8 +220,8 @@
+     # Dict Files
      input_files = [InFile(filename) for filename in io.glob("brkitr/dictionaries/*.txt")]
      output_files = [OutFile("brkitr/%s.dict" % v.filename[20:-4]) for v in input_files]
++    output_files = filter(lambda f: 'burmese' not in f, output_files)
      extra_options_map = {
 -        "brkitr/dictionaries/burmesedict.txt": "--bytes --transform offset-0x1000",
          "brkitr/dictionaries/cjdict.txt": "--uchars",

--- a/packages/icu/SPECS/icu.spec
+++ b/packages/icu/SPECS/icu.spec
@@ -64,6 +64,8 @@ BuildArch: noarch
 
 %build
 cd source
+rm data/in/icudt67l.dat
+cp %{_sourcedir}/icudt67l.dat data/in
 autoconf
 export LD_LIBRARYN32_PATH="%{_builddir}/icu/source/lib:$LD_LIBRARYN32_PATH"
 export LD_LIBRARYN32_PATH="%{_builddir}/icu/source/stubdata:$LD_LIBRARYN32_PATH"


### PR DESCRIPTION
Our builds are now dying because of [an issue with the Burmese locales](https://gist.github.com/mach-kernel/edb0cbf54aee32d29fcfa4c19277a538) ??

Using another machine [and the instructions for the ICU build tools here](https://github.com/unicode-org/icu/blob/master/docs/userguide/icu_data/buildtool.md), I generated another `icudt67l.dat` file that filters on `en*` only. 