### PR TITLE
ICU4C: Try filters JSON???

### DIFF
--- a/packages/icu/SOURCES/icu-filters.json
+++ b/packages/icu/SOURCES/icu-filters.json
@@ -1,0 +1,8 @@
+{
+  "localeFilter": {
+    "filterType": "locale",
+    "whitelist": [
+      "en_US"
+    ]
+  }
+}

--- a/packages/icu/SPECS/icu.spec
+++ b/packages/icu/SPECS/icu.spec
@@ -66,9 +66,11 @@ BuildArch: noarch
 cd source
 rm data/in/icudt67l.dat
 cp %{_sourcedir}/icudt67l.dat data/in
+cp %{_sourcedir}/icu-filters.json .
 autoconf
 export LD_LIBRARYN32_PATH="%{_builddir}/icu/source/lib:$LD_LIBRARYN32_PATH"
 export LD_LIBRARYN32_PATH="%{_builddir}/icu/source/stubdata:$LD_LIBRARYN32_PATH"
+export ICU_DATA_FILTER_FILE="%{_builddir}/icu/source/icu-filters.json"
 CFLAGS='%optflags -fno-strict-aliasing'
 CXXFLAGS='%optflags -fno-strict-aliasing'
 # Endian: BE=0 LE=1


### PR DESCRIPTION
Running out of steam for this one. Noticed that [the ICU CI pipeline](https://github.com/unicode-org/icu/blob/9b3746e0b66c94375c57585d5b5cf3d03c4b3d1e/.ci-builds/.azure-pipelines.yml) applies filters with this JSON as part of the configure step. Don't think that running their script does anything different (`configure.ac` detects that environment variable). 

Don't merge this one until we get it working!