### PR TITLE
gobject-introspection: libc not automatically linked?

### DIFF
--- a/packages/gobject-introspection/SOURCES/gobject-introspection-lc-global.patch
+++ b/packages/gobject-introspection/SOURCES/gobject-introspection-lc-global.patch
@@ -1,0 +1,10 @@
+--- gobject-introspection-1.62.0.orig/meson.build  2019-09-09 15:22:10.000000000 +0000  
++++ gobject-introspection-1.62.0/meson.build       2020-06-11 22:25:48.393925120 +0000 
+@@ -101,6 +101,7 @@
+ endforeach
+
+ add_project_arguments(['-DHAVE_CONFIG_H'], language: 'c')
++add_global_link_arguments(['-lc'], language: 'c')
+
+ gi_hidden_visibility_cflags = []
+ if host_system == 'windows'

--- a/packages/gobject-introspection/SPECS/gobject-introspection.spec
+++ b/packages/gobject-introspection/SPECS/gobject-introspection.spec
@@ -12,6 +12,7 @@ URL:            https://wiki.gnome.org/Projects/GObjectIntrospection
 Source0:        https://download.gnome.org/sources/gobject-introspection/1.62/%{name}-%{version}.tar.xz
 
 Patch100:       gobject-introspection.sgifixes.patch
+Patch101:       gobject-introspection-lc-global.patch
 
 BuildRequires:  gcc
 BuildRequires:  bison
@@ -31,7 +32,7 @@ BuildRequires:  libxml2-devel
 BuildRequires:  meson
 BuildRequires:  python3-devel
 #BuildRequires:  python3-mako
-BuildRequires:  python3-markdown
+#BuildRequires:  python3-markdown
 
 #Requires:       glib2%{?_isa} >= %{glib2_version}
 
@@ -60,6 +61,7 @@ Libraries and headers for gobject-introspection
 
 %build
 export LD_LIBRARYN32_PATH=%{_builddir}/gobject-introspection-1.62.0/mips-sgug-irix/girepository/:$LD_LIBRARYN32_PATH
+export LIBS=-lc
 
 %meson -Ddoctool=true -Dgtk_doc=false -Dpython=%{__python3}
 %meson_build

--- a/packages/gobject-introspection/SPECS/gobject-introspection.spec
+++ b/packages/gobject-introspection/SPECS/gobject-introspection.spec
@@ -32,7 +32,7 @@ BuildRequires:  libxml2-devel
 BuildRequires:  meson
 BuildRequires:  python3-devel
 #BuildRequires:  python3-mako
-#BuildRequires:  python3-markdown
+BuildRequires:  python3-markdown
 
 #Requires:       glib2%{?_isa} >= %{glib2_version}
 
@@ -61,7 +61,6 @@ Libraries and headers for gobject-introspection
 
 %build
 export LD_LIBRARYN32_PATH=%{_builddir}/gobject-introspection-1.62.0/mips-sgug-irix/girepository/:$LD_LIBRARYN32_PATH
-export LIBS=-lc
 
 %meson -Ddoctool=true -Dgtk_doc=false -Dpython=%{__python3}
 %meson_build


### PR DESCRIPTION
I don't know if this affects only me, however this and `glib2` die with the below error. @onre pointed out that adding `-lc` should fix it (but should also not be necessary). Is this patch the wrong thing to do? I don't have any issues with any other RSE packages and the use of `-lc`.

The errors:

```
/usr/people/mach/rpmbuild/BUILD/gobject-introspection-1.62.0/mips-sgug-irix/../girepository/cmph/buffer_entry.c:83: undefined reference to `memcpy'
/usr/people/mach/rpmbuild/BUILD/gobject-introspection-1.62.0/mips-sgug-irix/../girepository/cmph/buffer_entry.c:48: undefined reference to `free'
```

My env:

```
MSGVERB=text:action
NOMSGSEVERITY=1
DISTCC_HOSTS=10.0.1.5:3632,lzo,cpp/24 10.0.1.15:3632,lzo,cpp/24
PWD=/usr/people/mach/workspace/sgug-rse
LOGNAME=mach
MANPATH=/usr/sgug/share/man:/usr/share/catman/a_man:/usr/share/catman/g_man:/usr/share/catman/p_man:/usr/share/catman/u_man
TZ=EST5EDT
HOME=/usr/people/mach
LD_LIBRARYN32_PATH=/usr/sgug/lib32:/usr/lib32:/lib32:/usr/lib:/lib
TERM=xterm
USER=mach
NOMSGLABEL=1
SHLVL=1
PS1=[sgugshell \u@\h \W]\$
LC_ALL=C
PATH=/usr/sgug/distccmasqbin:/usr/sgug/bin:/usr/bin/X11:/usr/bin:/bin:/usr/sbin:/usr/bsd
MAIL=/usr/mail/mach
SSH_TTY=/dev/ttyq0
OLDPWD=/usr/people/mach
_=/usr/sgug/bin/env
```