### PR TITLE
gdk-pixbuf2 fix postinstall loader cache issues

### DIFF
--- a/packages/gdk-pixbuf2/SOURCES/gdkpixbuf4.irixfixes.patch
+++ b/packages/gdk-pixbuf2/SOURCES/gdkpixbuf4.irixfixes.patch
@@ -1,22 +1,3 @@
-diff -Naur gdk-pixbuf-2.40.0.orig/build-aux/post-install.sh gdk-pixbuf-2.40.0/build-aux/post-install.sh
---- gdk-pixbuf-2.40.0.orig/build-aux/post-install.sh	2019-10-08 03:44:10.000000000 +0000
-+++ gdk-pixbuf-2.40.0/build-aux/post-install.sh	2020-05-29 13:00:32.767352623 +0000
--#!/bin/sh
-+#!/usr/sgug/bin/sh
-
- bindir="$1"
- libdir="$2"
- binary_version="$3"
-+unset $DESTDIR
-
- if [ -z "$DESTDIR" ]; then
-         mkdir -p "$libdir/gdk-pixbuf-2.0/$binary_version"
--        $bindir/gdk-pixbuf-query-loaders > "$libdir/gdk-pixbuf-2.0/$binary_version/loaders.cache"
-+        $bindir/gdk-pixbuf-query-loaders-32 > "$libdir/gdk-pixbuf-2.0/$binary_version/loaders.cache"
- else
-         echo "***"
-         echo "*** Warning: loaders.cache not built"
-diff -Naur gdk-pixbuf-2.40.0.orig/meson.build gdk-pixbuf-2.40.0/meson.build
 --- gdk-pixbuf-2.40.0.orig/meson.build	2019-10-08 03:44:10.000000000 +0000
 +++ gdk-pixbuf-2.40.0/meson.build	2020-05-29 13:00:32.769575383 +0000
 @@ -417,7 +417,9 @@

--- a/packages/gdk-pixbuf2/SOURCES/gdkpixbuf4.irixfixes.patch
+++ b/packages/gdk-pixbuf2/SOURCES/gdkpixbuf4.irixfixes.patch
@@ -1,3 +1,4 @@
+diff -Naur gdk-pixbuf-2.40.0.orig/meson.build gdk-pixbuf-2.40.0/meson.build
 --- gdk-pixbuf-2.40.0.orig/meson.build	2019-10-08 03:44:10.000000000 +0000
 +++ gdk-pixbuf-2.40.0/meson.build	2020-05-29 13:00:32.769575383 +0000
 @@ -417,7 +417,9 @@

--- a/packages/gdk-pixbuf2/SOURCES/gdkpixbuf4.irixfixes.patch
+++ b/packages/gdk-pixbuf2/SOURCES/gdkpixbuf4.irixfixes.patch
@@ -1,17 +1,14 @@
 diff -Naur gdk-pixbuf-2.40.0.orig/build-aux/post-install.sh gdk-pixbuf-2.40.0/build-aux/post-install.sh
 --- gdk-pixbuf-2.40.0.orig/build-aux/post-install.sh	2019-10-08 03:44:10.000000000 +0000
 +++ gdk-pixbuf-2.40.0/build-aux/post-install.sh	2020-05-29 13:00:32.767352623 +0000
-@@ -1,12 +1,12 @@
 -#!/bin/sh
 +#!/usr/sgug/bin/sh
- 
--bindir="$1"
--libdir="$2"
--binary_version="$3"
-+bindir="/usr/sgug/bin"
-+libdir="/usr/sgug/lib32"
-+binary_version="2.10.0$3"
- 
+
+ bindir="$1"
+ libdir="$2"
+ binary_version="$3"
++unset $DESTDIR
+
  if [ -z "$DESTDIR" ]; then
          mkdir -p "$libdir/gdk-pixbuf-2.0/$binary_version"
 -        $bindir/gdk-pixbuf-query-loaders > "$libdir/gdk-pixbuf-2.0/$binary_version/loaders.cache"

--- a/packages/gdk-pixbuf2/SPECS/gdk-pixbuf2.spec
+++ b/packages/gdk-pixbuf2/SPECS/gdk-pixbuf2.spec
@@ -99,6 +99,7 @@ chmod u+w  %{buildroot}%{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders.cache
 
 %find_lang gdk-pixbuf
 
+%{buildroot}/usr/sgug/bin/gdk-pixbuf-query-loaders-%{__isa_bits} > %{buildroot}/usr/sgug/lib32/gdk-pixbuf-2.0/2.10.0/loaders.cache
 #%%transfiletriggerin -- %{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders
 #%%transfiletriggerpostun -- %{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders
 

--- a/packages/gdk-pixbuf2/SPECS/gdk-pixbuf2.spec
+++ b/packages/gdk-pixbuf2/SPECS/gdk-pixbuf2.spec
@@ -85,17 +85,14 @@ export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}/gdk-pixbuf-2.0/2.10.0/:$LD_LIBR
        -Dinstalled_tests=false \
        -Djasper=false \
 
-%global _smp_mflags -j1
 %meson_build
 
 %install
 %meson_install
 
 mkdir -p $RPM_BUILD_ROOT%{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders/
-# echo %{buildroot}%{_libdir}/gdk-pixbuf-2.0/2.10.0/
 touch %{buildroot}%{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders.cache
 chmod u+w  %{buildroot}%{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders.cache
-#touch $RPM_BUILD_ROOT%{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders.cache
 (cd $RPM_BUILD_ROOT%{_bindir}
  mv gdk-pixbuf-query-loaders gdk-pixbuf-query-loaders-%{__isa_bits}
 )
@@ -103,12 +100,7 @@ chmod u+w  %{buildroot}%{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders.cache
 %find_lang gdk-pixbuf
 
 #%%transfiletriggerin -- %{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders
-%{buildroot}/usr/sgug/bin/gdk-pixbuf-query-loaders-%{__isa_bits} --update-cache
-#/gdk-pixbuf-query-loaders-%{__isa_bits} --update-cache
-
 #%%transfiletriggerpostun -- %{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders
-%{buildroot}/usr/sgug/bin/gdk-pixbuf-query-loaders-%{__isa_bits} --update-cache
-#/gdk-pixbuf-query-loaders-%{__isa_bits} --update-cache
 
 %files -f gdk-pixbuf.lang
 %license COPYING

--- a/packages/gdk-pixbuf2/SPECS/gdk-pixbuf2.spec
+++ b/packages/gdk-pixbuf2/SPECS/gdk-pixbuf2.spec
@@ -99,7 +99,12 @@ chmod u+w  %{buildroot}%{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders.cache
 
 %find_lang gdk-pixbuf
 
-%{buildroot}/usr/sgug/bin/gdk-pixbuf-query-loaders-%{__isa_bits} > %{buildroot}/usr/sgug/lib%{__isa_bits}/gdk-pixbuf-2.0/2.10.0/loaders.cache
+%if %{__isa_bits} == 32
+%{buildroot}/usr/sgug/bin/gdk-pixbuf-query-loaders-%{__isa_bits} > %{buildroot}/usr/sgug/lib32/gdk-pixbuf-2.0/2.10.0/loaders.cache
+%else
+%{buildroot}/usr/sgug/bin/gdk-pixbuf-query-loaders-%{__isa_bits} > %{buildroot}/usr/sgug/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
+%endif
+
 #%%transfiletriggerin -- %{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders
 #%%transfiletriggerpostun -- %{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders
 

--- a/packages/gdk-pixbuf2/SPECS/gdk-pixbuf2.spec
+++ b/packages/gdk-pixbuf2/SPECS/gdk-pixbuf2.spec
@@ -99,7 +99,7 @@ chmod u+w  %{buildroot}%{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders.cache
 
 %find_lang gdk-pixbuf
 
-%{buildroot}/usr/sgug/bin/gdk-pixbuf-query-loaders-%{__isa_bits} > %{buildroot}/usr/sgug/lib32/gdk-pixbuf-2.0/2.10.0/loaders.cache
+%{buildroot}/usr/sgug/bin/gdk-pixbuf-query-loaders-%{__isa_bits} > %{buildroot}/usr/sgug/lib%{__isa_bits}/gdk-pixbuf-2.0/2.10.0/loaders.cache
 #%%transfiletriggerin -- %{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders
 #%%transfiletriggerpostun -- %{_libdir}/gdk-pixbuf-2.0/2.10.0/loaders
 


### PR DESCRIPTION


It looks like gdk-pixbuf is responsible for generating `loaders.cache`:

```
build-aux/post-install.sh:9:        $bindir/gdk-pixbuf-query-loaders-32 > "$libdir/gdk-pixbuf-2.0/$binary_version/loaders.cache"
```

Ended up dropping the patch for the `build-aux` script altogether and running the gen command from the spec, to preserve the `isa-bits` functionality which would not have been provided by `postinstall.sh`