### PR TITLE
gtk2: fix libtool wrapper issue, missing immodules query

### DIFF
--- a/packages/gtk2/SPECS/gtk2.spec
+++ b/packages/gtk2/SPECS/gtk2.spec
@@ -238,7 +238,7 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/X11/xinit/xinput.d
 cp %{SOURCE3} $RPM_BUILD_ROOT%{_sysconfdir}/X11/xinit/xinput.d
 
 # Explicitly use python2 shebang instead of ambiguous python
-sed -i -e '/^#!\// s/python$/python2/' $RPM_BUILD_ROOT%{_bindir}/gtk-builder-convert
+# sed -i -e '/^#!\// s/python$/python2/' $RPM_BUILD_ROOT%{_bindir}/gtk-builder-convert
 
 # Remove unpackaged files
 rm $RPM_BUILD_ROOT%{_libdir}/*.la

--- a/packages/gtk2/SPECS/gtk2.spec
+++ b/packages/gtk2/SPECS/gtk2.spec
@@ -145,7 +145,9 @@ This package contains developer documentation for the GTK+ widget toolkit.
 %prep
 %autosetup -n gtk+-%{version} -p1
 export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}:$LD_LIBRARYN32_PATH
-export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}/gtk-2.0/2.10.0:$LD_LIBRARYN32_PATH
+export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}/gtk-2.0/2.10.0/engines:$LD_LIBRARYN32_PATH
+export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}/gtk-2.0/2.10.0/immodules:$LD_LIBRARYN32_PATH
+export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}/gtk-2.0/2.10.0/printbackends:$LD_LIBRARYN32_PATH
 
 %build
 export CFLAGS='-fno-strict-aliasing %optflags'

--- a/packages/gtk2/SPECS/gtk2.spec
+++ b/packages/gtk2/SPECS/gtk2.spec
@@ -143,11 +143,8 @@ BuildArch: noarch
 This package contains developer documentation for the GTK+ widget toolkit.
 
 %prep
+#autoreconf -fi gtk+-%{version}
 %autosetup -n gtk+-%{version} -p1
-export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}:$LD_LIBRARYN32_PATH
-export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}/gtk-2.0/2.10.0/engines:$LD_LIBRARYN32_PATH
-export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}/gtk-2.0/2.10.0/immodules:$LD_LIBRARYN32_PATH
-export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}/gtk-2.0/2.10.0/printbackends:$LD_LIBRARYN32_PATH
 
 %build
 export CFLAGS='-fno-strict-aliasing %optflags'
@@ -163,6 +160,8 @@ export XDG_DATA_DIRS=/usr/sgug/share
 )
 
 # fight unused direct deps
+rm libtool
+cp /usr/sgug/bin/libtool libtool
 sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
 
 make %{?_smp_mflags}
@@ -248,6 +247,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 rm $RPM_BUILD_ROOT%{_libdir}/gtk-2.0/*/*.la
 rm $RPM_BUILD_ROOT%{_libdir}/gtk-2.0/%{bin_version}/*/*.la
 rm $RPM_BUILD_ROOT%{_bindir}/gtk-update-icon-cache
+rm $RPM_BUILD_ROOT%{_libdir}/*.a
+rm $RPM_BUILD_ROOT%{_libdir}/gtk-2.0/*/*.a
+rm $RPM_BUILD_ROOT%{_libdir}/gtk-2.0/%{bin_version}/*/*.a
 #rm $RPM_BUILD_ROOT%{_mandir}/man1/gtk-update-icon-cache.1*
 
 touch $RPM_BUILD_ROOT%{_libdir}/gtk-2.0/%{bin_version}/immodules.cache

--- a/packages/gtk2/SPECS/gtk2.spec
+++ b/packages/gtk2/SPECS/gtk2.spec
@@ -144,11 +144,12 @@ This package contains developer documentation for the GTK+ widget toolkit.
 
 %prep
 %autosetup -n gtk+-%{version} -p1
+export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}:$LD_LIBRARYN32_PATH
+export LD_LIBRARYN32_PATH=%{_builddir}%{_libdir}/gtk-2.0/2.10.0:$LD_LIBRARYN32_PATH
 
 %build
 export CFLAGS='-fno-strict-aliasing %optflags'
 export XDG_DATA_DIRS=/usr/sgug/share
-#export CFLAGS="${CFLAGS} -DGTK_DATADIR=/usr/sgug/share/mime"
 (if ! test -x configure; then NOCONFIGURE=1 ./autogen.sh; CONFIGFLAGS=--disable-gtk-doc; fi;
  %configure $CONFIGFLAGS \
 	--enable-man		\

--- a/packages/gtk2/SPECS/gtk2.spec
+++ b/packages/gtk2/SPECS/gtk2.spec
@@ -262,7 +262,7 @@ gtk-query-immodules-2.0-%{__isa_bits} --update-cache
 %files -f gtk20.lang
 %license COPYING
 %doc AUTHORS NEWS README
-%{_bindir}/gtk-query-immodules-2.0
+%{_bindir}/gtk-query-immodules-2.0-%{__isa_bits}
 %{_bindir}/update-gtk-immodules
 %{_libdir}/libgtk-x11-2.0.so.*
 %{_libdir}/libgdk-x11-2.0.so.*

--- a/packages/gtk2/SPECS/gtk2.spec
+++ b/packages/gtk2/SPECS/gtk2.spec
@@ -238,7 +238,7 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/X11/xinit/xinput.d
 cp %{SOURCE3} $RPM_BUILD_ROOT%{_sysconfdir}/X11/xinit/xinput.d
 
 # Explicitly use python2 shebang instead of ambiguous python
-# sed -i -e '/^#!\// s/python$/python2/' $RPM_BUILD_ROOT%{_bindir}/gtk-builder-convert
+sed -i -e 's/^#!.*$/#!\/usr\/sgug\/bin\/python/' $RPM_BUILD_ROOT%{_bindir}/gtk-builder-convert
 
 # Remove unpackaged files
 rm $RPM_BUILD_ROOT%{_libdir}/*.la

--- a/packages/gtk2/SPECS/gtk2.spec
+++ b/packages/gtk2/SPECS/gtk2.spec
@@ -224,14 +224,11 @@ make install DESTDIR=$RPM_BUILD_ROOT        \
 # We need to have separate 32-bit and 64-bit binaries
 # for places where we have two copies of the GTK+ package installed.
 # (we might have x86_64 and i686 packages on the same system, for example.)
-#case "$host" in
-#  alpha*|ia64*|ppc64*|powerpc64*|s390x*|x86_64*|aarch64*|mips64*)
-#   mv $RPM_BUILD_ROOT%{_bindir}/gtk-query-immodules-2.0 $RPM_BUILD_ROOT%{_bindir}/gtk-query-immodules-2.0-64
-#   ;;
-#  *)
-#   mv $RPM_BUILD_ROOT%{_bindir}/gtk-query-immodules-2.0 $RPM_BUILD_ROOT%{_bindir}/gtk-query-immodules-2.0-32
-#   ;;
-#esac
+%if %{__isa_bits} == 64
+mv $RPM_BUILD_ROOT%{_bindir}/gtk-query-immodules-2.0 $RPM_BUILD_ROOT%{_bindir}/gtk-query-immodules-2.0-64
+%else
+mv $RPM_BUILD_ROOT%{_bindir}/gtk-query-immodules-2.0 $RPM_BUILD_ROOT%{_bindir}/gtk-query-immodules-2.0-32
+%endif
 
 # Install wrappers for the binaries
 cp %{SOURCE2} $RPM_BUILD_ROOT%{_bindir}/update-gtk-immodules
@@ -255,7 +252,6 @@ touch $RPM_BUILD_ROOT%{_libdir}/gtk-2.0/%{bin_version}/immodules.cache
 mkdir -p $RPM_BUILD_ROOT%{_libdir}/gtk-2.0/modules
 mkdir -p $RPM_BUILD_ROOT%{_libdir}/gtk-2.0/immodules
 mkdir -p $RPM_BUILD_ROOT%{_libdir}/gtk-2.0/%{bin_version}/filesystems
-
 
 %transfiletriggerin -- %{_libdir}/gtk-2.0/immodules/ %{_libdir}/gtk-2.0/%{bin_version}/immodules/
 gtk-query-immodules-2.0-%{__isa_bits} --update-cache


### PR DESCRIPTION
Changes:

- `rm` generated libtool from builddir and copy ours from `/usr/sgug/bin` (is there a better way? `autoreconf` did not work)
- Replace case statement with `%{_isa_bits}`
- Update `gtk-builder-convert` Python to point to `/usr/sgug/bin/python`
- There are now some extra `.a` files that are produced with our libtool -- will deleting these break anything?

[Build log](https://gist.github.com/mach-kernel/3a3bc8ccd54d12002536b6b4a434ea09)

Install log:

```
[sgugshell mach@octane SPECS]$ sudo rpm -ivh ~/rpmbuild/RPMS/mips/gtk2*.rpm
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:gtk2-2.24.32-5.sgugbeta          ################################# [ 25%]
   2:gtk2-devel-2.24.32-5.sgugbeta    ################################# [ 50%]
   3:gtk2-immodule-xim-2.24.32-5.sgugb################################# [ 75%]
   4:gtk2-immodules-2.24.32-5.sgugbeta################################# [100%]
```

