### PR TITLE
Add hunspell-en

### DIFF
--- a/packages/hunspell-en/SOURCES/en_GB-singleletters.patch
+++ b/packages/hunspell-en/SOURCES/en_GB-singleletters.patch
@@ -1,0 +1,56 @@
+--- wordlist.orig/en_GB.dic	2005-05-26 11:49:30.000000000 +0100
++++ wordlist/en_GB.dic	2008-11-28 10:01:37.000000000 +0000
+@@ -1,4 +1,4 @@
+-46280
++46286
+ abaft
+ abbreviation/M
+ abdicate/DNGSn
+@@ -2278,6 +2278,7 @@
+ hysterectomy/SM
+ Hyundai/M
+ ICC/M
++i
+ icebox/SM
+ icicle/SM
+ iconoclasm/MS
+@@ -2470,6 +2471,7 @@
+ Ithacan
+ its
+ ix
++j
+ jackknife/DGMS
+ Jacqueline
+ Jaeger/M
+@@ -2764,6 +2766,7 @@
+ Mabel/M
+ Macedon
+ Macedonia/M
++m
+ macintosh/SM
+ MacIntyre
+ Mackenzie
+@@ -3222,6 +3225,7 @@
+ nuttiness/S
+ nymphomaniac/S
+ Oakland/M
++o
+ ob.
+ obeyer/EM
+ obfuscation/M
+@@ -4797,6 +4801,7 @@
+ tyro/SM
+ UFO/S
+ Ukrainian/S
++u
+ ulcerate/SGNDn
+ ulcerous
+ Ulrika/M
+@@ -4962,6 +4967,7 @@
+ vulnerability/SI
+ vulva/M
+ WAC
++w
+ wagon/SM
+ waitress/MS
+ Waldemar/M

--- a/packages/hunspell-en/SOURCES/en_GB.etc.patch
+++ b/packages/hunspell-en/SOURCES/en_GB.etc.patch
@@ -1,0 +1,11 @@
+--- wordlist.orig/en_GB.dic	2017-09-21 11:24:10.673817684 +0100
++++ wordlist/en_GB.dic	2017-09-21 11:31:39.596987079 +0100
+@@ -27307,7 +27307,7 @@
+ estimations/f
+ estrange/DGLS
+ estranger/M
+-etc.
++etc
+ eternal/PY
+ ethereal/PY
+ ethic/3MSY

--- a/packages/hunspell-en/SOURCES/en_GB.two_initial_caps.patch
+++ b/packages/hunspell-en/SOURCES/en_GB.two_initial_caps.patch
@@ -1,0 +1,20 @@
+--- wordlist.orig/en_GB.dic	2009-06-06 15:16:16.000000000 +0100
++++ wordlist/en_GB.dic	2009-06-06 15:17:28.000000000 +0100
+@@ -19953,7 +19953,7 @@
+ technology/3wSM1
+ Ted/M
+ tee/SGdM
+-TEirtza/M
++Teirtza/M
+ tellurium/M
+ temp/GMRSTD
+ tempera/MLS
+@@ -41226,7 +41226,7 @@
+ adore/lRSNnGkD
+ Adrian/M
+ adroit/TYP
+-ADte
++ADTe
+ adulterer/SM
+ adumbration/M
+ advantageousness/E

--- a/packages/hunspell-en/SOURCES/en_IE.supplemental.patch
+++ b/packages/hunspell-en/SOURCES/en_IE.supplemental.patch
@@ -1,0 +1,16 @@
+--- wordlist/en_GB.dic.orig	2012-04-10 22:51:16.471732570 +0100
++++ wordlist/en_GB.dic	2012-04-10 22:55:00.018995514 +0100
+@@ -1,4 +1,4 @@
+-46285
++46286
+ abaft
+ abbreviation/M
+ abdicate/DNGSn
+@@ -22588,6 +22588,7 @@
+ halter/d
+ halyard/MS
+ Hamal/M
++hames
+ Hamlin/M
+ hamper/dS
+ handbag/SMDG

--- a/packages/hunspell-en/SOURCES/en_US-strippedabbrevs.patch
+++ b/packages/hunspell-en/SOURCES/en_US-strippedabbrevs.patch
@@ -1,0 +1,8 @@
+--- scowl/speller/en.dic.supp.orig	2008-11-28 10:10:01.000000000 +0000
++++ scowl/speller/en.dic.supp	2008-11-28 10:10:10.000000000 +0000
+@@ -21,3 +21,5 @@
+ 7th/pt
+ 8th/pt
+ 9th/pt
++e.g.
++i.e.

--- a/packages/hunspell-en/SOURCES/hunspell-en-SI_and_IEC.patch
+++ b/packages/hunspell-en/SOURCES/hunspell-en-SI_and_IEC.patch
@@ -1,0 +1,90 @@
+--- scowl/r/special/abbreviations	2008-11-29 23:02:41.000000000 +0000
++++ scowl/r/special/abbreviations	2010-07-30 11:18:33.000000000 +0100
+@@ -3,6 +3,11 @@
+ API
+ ATM
+ BTW
++EB
++Eb
++Ei
++EiB
++Eib
+ EULA
+ EULAs
+ FAQ
+@@ -16,39 +21,75 @@
+ GIF
+ GPU
+ GUI
++Gb
++Gi
++GiB
++Gib
+ GnuPG
+ HDD
+ HDMI
+ HTML
+ HTTP
++IEC
+ IMHO
+ IMNSHO
+ IMO
+ IRC
+ ISO
++JEDEC
++KB
++Kb
++Ki
++KiB
++Kib
+ JPEG
+ MB
+ MP3
+ MP3s
+ MPEG
+ Mb
++Mi
++MiB
++Mib
+ OTOH
+ PCMCIA
+ PDF
+ PGP
++PB
++Pb
++Pi
++PiB
++Pib
+ RFC
+ ROFL
+ RTFM
+ SQL
++TB
++Tb
++Ti
++TiB
++Tib
+ URL
+ USB
+ USB
+ WWW
+ WYSIWYG
+ XML
++YB
++Yb
++Yi
++YiB
++Yib
+ YMMV
++ZB
++Zb
++Zi
++ZiB
++Zib
+ cf
+ dpi
++kB
++kb
+ pp
+ resp
+ vs

--- a/packages/hunspell-en/SOURCES/hunspell-en-allow-non-typographical.marks.patch
+++ b/packages/hunspell-en/SOURCES/hunspell-en-allow-non-typographical.marks.patch
@@ -1,0 +1,21 @@
+--- en_GB.aff	2010-04-15 14:51:13.000000000 +0100
++++ en_GB.aff	2010-04-15 14:52:07.000000000 +0100
+@@ -6,6 +6,7 @@
+ # R 1.18, 11/04/05
+ SET ISO8859-1
+ TRY esiaÈnrtolcdugmfphbyvkw-'.zqjxSNRTLCGDMFPHBEAUYOIVKWÛˆ‚ÙZQJX≈ÁËÓÍ‡Ô¸‰Ò
++WORDCHARS 0123456789'
+ REP 27
+ REP f ph
+ REP ph f
+--- scowl/speller/en.aff	2010-04-15 14:56:37.000000000 +0100
++++ scowl/speller/en.aff	2010-04-15 14:57:08.000000000 +0100
+@@ -12,7 +12,7 @@
+ COMPOUNDRULE 2
+ COMPOUNDRULE n*1t
+ COMPOUNDRULE n*mp
+-WORDCHARS 0123456789
++WORDCHARS 0123456789'
+ 
+ PFX A Y 1
+ PFX A   0     re         .

--- a/packages/hunspell-en/SOURCES/hunspell-en-calender.patch
+++ b/packages/hunspell-en/SOURCES/hunspell-en-calender.patch
@@ -1,0 +1,37 @@
+--- wordlist/en_GB.dic	2011-02-08 11:43:16.730271377 +0000
++++ wordlist/en_GB.dic	2011-02-08 11:43:35.261482189 +0000
+@@ -1,4 +1,4 @@
+-46286
++46285
+ abaft
+ abbreviation/M
+ abdicate/DNGSn
+@@ -643,7 +643,6 @@
+ Calder
+ caldera/SM
+ caldron's
+-calender/dMS
+ calibrate/SAGDN
+ calibrater's
+ calico/M
+--- wordlist/alt12dicts/2of12full.txt	2011-02-08 11:55:46.478837084 +0000
++++ wordlist/alt12dicts/2of12full.txt	2011-02-08 11:59:12.455202478 +0000
+@@ -6468,7 +6468,6 @@
+ 12: 12  -#  -&   calendar
+  2:  1  1#  -&   calendar month
+  2:  1  1#  -&   calendar year
+- 4:  4  -#  -&   calender
+ 12: 12  -#  -&   calf
+  9:  8  1#  -&   calfskin
+  3:  3  -#  -&   Calgary
+diff -ru wordlist/alt12dicts/5desk.txt wordlist/alt12dicts/5desk.txt
+--- wordlist/alt12dicts/5desk.txt	2011-02-08 11:55:46.548837888 +0000
++++ wordlist/alt12dicts/5desk.txt	2011-02-08 11:58:55.162003701 +0000
+@@ -7353,7 +7353,6 @@
+ Caledonia
+ Caledonian
+ calendar
+-calender
+ calendric
+ calendrical
+ calends

--- a/packages/hunspell-en/SOURCES/hunspell-en-dont-call-git-during-build.patch
+++ b/packages/hunspell-en/SOURCES/hunspell-en-dont-call-git-during-build.patch
@@ -1,0 +1,9 @@
+--- wordlist/scowl/README.in	2014-10-08 14:00:05.682971887 +0100
++++ wordlist/scowl/README.in	2014-10-08 14:00:12.369050485 +0100
+@@ -1,6 +1,4 @@
+ Spell Checking Oriented Word Lists (SCOWL)
+-@`if [ "$SCOWL_VERSION" ]; then echo -n "Version $SCOWL_VERSION"; fi`
+-@`git log --pretty=format:'%cd [%h]' -n 1 --`
+ by Kevin Atkinson (kevina@gnu.org)
+ 
+ The SCOWL is a collection of word lists split up in various sizes, and

--- a/packages/hunspell-en/SOURCES/hunspell-en-fixbuild.patch
+++ b/packages/hunspell-en/SOURCES/hunspell-en-fixbuild.patch
@@ -1,0 +1,10 @@
+diff -ru wordlist/scowl/src/deaccent.hh wordlist/scowl/src/deaccent.hh
+--- wordlist/scowl/src/deaccent.hh
++++ wordlist/scowl/src/deaccent.hh
+@@ -1,5 +1,5 @@
+ 
+-static const char deaccent_lookup[256] = {
++static const unsigned char deaccent_lookup[256] = {
+ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 
+ 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 
+ 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 

--- a/packages/hunspell-en/SOURCES/hunspell-en-irregular-plural-possessive.patch
+++ b/packages/hunspell-en/SOURCES/hunspell-en-irregular-plural-possessive.patch
@@ -1,0 +1,18 @@
+--- wordlist.orig/scowl/src/add-affixes	2012-10-11 13:05:58.864864580 +0100
++++ wordlist/scowl/src/add-affixes	2012-10-11 14:11:05.144908897 +0100
+@@ -74,6 +74,15 @@
+   @a = grep {not $remove{"$w:$p:$_"}} @a;
+   next unless @a;
+   $lookup{$w} .= join("\n",@a)."\n";
++  next unless $p eq 'N';
++
++  # For irregular nouns that have plurals that do not end in s
++  # then add the possessive form of the plural as well
++  foreach (@a) {
++      next unless (substr($_,-1,1) ne 's');
++      $possessive{$_} = "$_\'s\n";
++      $lookup{$w} .= $possessive{$_};
++  }
+ }
+ 
+ unless ($no_possessive) {

--- a/packages/hunspell-en/SOURCES/mozilla_words.patch
+++ b/packages/hunspell-en/SOURCES/mozilla_words.patch
@@ -1,0 +1,66 @@
+--- scowl/r/special/proper-names	2008-02-08 11:53:27.000000000 +0000
++++ scowl/r/special/proper-names	2008-02-08 12:06:00.000000000 +0000
+@@ -8,6 +8,8 @@
+ BitTorrent
+ Bluetooth
+ Bugzilla
++Camino
++ChatZilla
+ Closure
+ Debian
+ Dropbox
+@@ -19,23 +21,28 @@
+ GNU
+ Gentoo
+ GitHub
++Haskell
+ Hunspell
+ ISO
+ Instagram
+ Ispell
+ LibreOffice
+ LyX
++Mandriva
+ Mozilla
++MySpell
+ NSA
+ Netflix
+ OpenOffice
+ PayPal
+ PowerPC
+ Roku
++SeaMonkey
+ SUSE
+ Scala
+ Slackware
+ Sourceforge
++Sunbird
+ Thunderbird
+ Twitter
+ Ubuntu
+--- scowl/speller/en.aff	2008-02-08 20:28:24.000000000 +0000
++++ scowl/speller/en.aff	2008-02-08 20:28:45.000000000 +0000
+@@ -110,13 +110,17 @@
+ SFX L Y 1
+ SFX L   0     ment       .
+ 
+-REP 88
++SFX i N 1
++SFX i   us    i          us
++
++REP 90
+ REP a ei
+ REP ei a
+ REP a ey
+ REP ey a
+ REP ai ie
+ REP ie ai
++REP alot a_lot
+ REP are air
+ REP are ear
+ REP are eir
+@@ -199,3 +203,4 @@
+ REP shun tion
+ REP shun sion
+ REP shun cion
++REP sitted sat

--- a/packages/hunspell-en/SOURCES/perl.regex.patch
+++ b/packages/hunspell-en/SOURCES/perl.regex.patch
@@ -1,0 +1,22 @@
+--- a/scowl/src/add-affixes	2017-09-25 11:58:46.898706402 +0100
++++ b/scowl/src/add-affixes	2017-09-25 11:59:46.952904766 +0100
+@@ -72,7 +72,7 @@
+   next unless $q eq '' || $use_all >= 2;
+   my @a = split /, | \| /, $a;
+   @a = grep {my ($word,$tags,$level)
+-		 = /^([A-Za-z\']+)([~<!?]*)(| [\d.]+)(| {\S+})$/ or die $_;
++		 = /^([A-Za-z\']+)([~<!?]*)(| [\d.]+)(| \{\S+\})$/ or die $_;
+ 	     $_ = $word;
+ 	     $tags !~ /~|\?|!</ && $level <= $inc_level} @a;
+   @a = grep {not $remove{"$w:$p:$_"}} @a;
+--- a/scowl/src/add-other-forms	2017-09-25 12:04:44.139040499 +0100
++++ b/scowl/src/add-other-forms	2017-09-25 12:04:55.521509492 +0100
+@@ -11,7 +11,7 @@
+   splice @a0, -1, 0, "'" if $p eq 'V' && @a0 >= 3; # insert placeholder
+   @a = ();
+   foreach (@a0) {
+-    s/ {.+?}//g; s/ \(.+?\)//g; 
++    s/ \{.+?\}//g; s/ \(.+?\)//g; 
+     s/ \| / /g; s/ \/ / /g;
+     push @a, (split / /, $_);
+   }

--- a/packages/hunspell-en/SPECS/hunspell-en.spec
+++ b/packages/hunspell-en/SPECS/hunspell-en.spec
@@ -1,0 +1,363 @@
+Name: hunspell-en
+Summary: English hunspell dictionaries
+%global upstreamid 20140811.1
+Version: 0.%{upstreamid}
+Release: 16%{?dist}
+Source0: https://github.com/en-wl/wordlist/archive/rel-2014.08.11.1.tar.gz
+Source1: http://download.services.openoffice.org/contrib/dictionaries/en_GB.zip
+#See http://mxr.mozilla.org/mozilla/source/extensions/spellcheck/locales/en-US/hunspell/mozilla_words.diff?raw=1
+Patch0: mozilla_words.patch
+Patch1: en_GB-singleletters.patch
+Patch2: en_GB.two_initial_caps.patch
+#See http://sourceforge.net/tracker/?func=detail&aid=2355344&group_id=10079&atid=1014602
+#filter removes words with "." in them
+Patch3: en_US-strippedabbrevs.patch
+#See https://sourceforge.net/tracker/?func=detail&aid=2987192&group_id=143754&atid=756397
+#to allow "didn't" instead of suggesting change to typographical apostrophe
+Patch4: hunspell-en-allow-non-typographical.marks.patch
+#See https://sourceforge.net/tracker/?func=detail&aid=3012183&group_id=10079&atid=1014602
+#See https://bugzilla.redhat.com/show_bug.cgi?id=619577 add SI and IEC prefixes
+Patch5: hunspell-en-SI_and_IEC.patch
+#See https://sourceforge.net/tracker/?func=detail&aid=3175662&group_id=10079&atid=1014602 obscure Calender hides misspelling of Calendar
+Patch6: hunspell-en-calender.patch
+#valid English words that are archaic or rare in en-GB but not in en-IE
+Patch7: en_IE.supplemental.patch
+#call git to get the release hash, but this is a tarball
+Patch8: hunspell-en-dont-call-git-during-build.patch
+#fix build
+Patch9: hunspell-en-fixbuild.patch
+#rhbz#1492306 for better or worse treat etc the same in US and GB
+Patch10: en_GB.etc.patch
+#rhbz#1494968 perl tightened up regex rules
+Patch11: perl.regex.patch
+URL: http://wordlist.sourceforge.net/
+# README_en_GB.txt has specified just LGPL which mean LGPLv2+
+# scowl/speller/aspell/en_affix.dat is BSD
+# scowl/speller/aspell/en_phonet.dat is LGPLv2
+License: LGPLv2+ and LGPLv2 and BSD
+BuildArch: noarch
+BuildRequires: aspell, zip, dos2unix, perl-Getopt-Long, gcc-c++
+Requires: hunspell
+Requires: hunspell-en-US = %{version}-%{release}
+Requires: hunspell-en-GB = %{version}-%{release}
+Supplements: (hunspell and langpacks-en)
+
+%description
+English (US, UK, etc.) hunspell dictionaries
+
+%package US
+Requires: hunspell
+Summary: US English hunspell dictionaries
+
+%description US
+US English hunspell dictionaries
+
+%package GB
+Requires: hunspell
+Supplements: (hunspell and langpacks-en_GB)
+Summary: UK English hunspell dictionaries
+
+%description GB
+UK English hunspell dictionaries
+
+%prep
+%setup -q -n wordlist-rel-2014.08.11.1
+%setup -q -T -D -a 1 -n wordlist-rel-2014.08.11.1
+%patch0 -p0 -b .mozilla
+%patch1 -p1 -b .singleletters
+%patch2 -p1 -b .two_initial_cap
+%patch3 -p0 -b .strippedabbrevs
+%patch4 -p0 -b .allow-non-typographical
+%patch5 -p0 -b .SI_and_IEC
+%patch6 -p1 -b .calender
+%patch7 -p1 -b .en_IE
+%patch8 -p1 -b .nogit
+%patch9 -p1 -b .fixbuild
+%patch10 -p1 -b .etc
+%patch11 -p1 -b .regex
+
+%build
+grep -rnil '#!/usr/bin/perl' | xargs sed -i 's,#!/usr/bin/perl,#!/usr/sgug/bin/perl,'
+export PERL5LIB=`pwd`/scowl/r/varcon${PERL5LIB:+:${PERL5LIB}}
+make
+cd scowl/speller
+make hunspell
+for i in README_en_CA.txt README_en_US.txt; do
+  if ! iconv -f utf-8 -t utf-8 -o /dev/null $i > /dev/null 2>&1; then
+    iconv -f ISO-8859-1 -t UTF-8 $i > $i.new
+    touch -r $i $i.new
+    mv -f $i.new $i
+  fi
+  tr -d '\r' < $i > $i.new
+  touch -r $i $i.new
+  mv -f $i.new $i
+done
+
+%install
+mkdir -p $RPM_BUILD_ROOT/%{_datadir}/myspell
+cp -p en_??.dic en_??.aff $RPM_BUILD_ROOT/%{_datadir}/myspell
+cd scowl/speller
+cp -p en_??.dic en_??.aff $RPM_BUILD_ROOT/%{_datadir}/myspell
+
+prev=$(pwd)
+cd $RPM_BUILD_ROOT/%{_datadir}/myspell/
+en_GB_aliases="en_AG en_AU en_BS en_BW en_BZ en_DK en_GH en_HK en_IE en_IN en_JM en_MW en_NA en_NG en_NZ en_SG en_TT en_ZA en_ZM en_ZW"
+for lang in $en_GB_aliases; do
+	ln -s en_GB.aff $lang.aff
+	ln -s en_GB.dic $lang.dic
+done
+en_US_aliases="en_PH"
+for lang in $en_US_aliases; do
+	ln -s en_US.aff $lang.aff
+	ln -s en_US.dic $lang.dic
+done
+cd $prev
+
+%files
+%doc scowl/speller/README_en_CA.txt
+%{_datadir}/myspell/*
+%exclude %{_datadir}/myspell/en_GB.*
+%exclude %{_datadir}/myspell/en_US.*
+
+%files US
+%doc scowl/speller/README_en_US.txt
+%{_datadir}/myspell/en_US.*
+
+%files GB
+%doc README_en_GB.txt
+%{_datadir}/myspell/en_GB.*
+
+%changelog
+* Thu Jun 18 2020 David Stancu <dstancu@nyu.edu> - 0.20140811.1-16
+- Use RSE Perl
+
+* Wed Jan 29 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.20140811.1-16
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
+
+* Thu Jul 25 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.20140811.1-15
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
+
+* Fri Feb 01 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.20140811.1-14
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_30_Mass_Rebuild
+
+* Fri Jul 13 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.20140811.1-13
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
+
+* Sun Jul 08 2018 Parag Nemade <pnemade AT fedoraproject DOT org> - 0.20140811.1-12
+- Update Source tag
+
+* Wed Feb 07 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.20140811.1-11
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild
+
+* Mon Nov 20 2017 Peter Oliver <rpm@mavit.org.uk> - 0.20140811.1-10
+- Have hunspell-en-GB installed when langpacks-en_GB is installed.
+  Resolves: rhbz#1409136.
+
+* Mon Sep 25 2017 Caolán McNamara <caolanm@redhat.com> - 0.20140811.1-9
+- Resolves: rhbz#1494968 perl regex rule changes result in broken en_US dict
+
+* Thu Sep 21 2017 Caolán McNamara <caolanm@redhat.com> - 0.20140811.1-8
+- Resolves: rhbz#1492306 for better or worse treat etc the same in US and GB
+
+* Wed Jul 26 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.20140811.1-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
+
+* Fri Feb 10 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.20140811.1-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
+
+* Fri Feb 19 2016 Parag Nemade <pnemade AT redhat DOT com> - 0.20140811.1-5
+- Add Supplements: tag for langpacks naming guidelines
+- Clean the specfile to follow current packaging guidelines
+
+* Mon Feb 15 2016 Caolán McNamara <caolanm@redhat.com> - 0.20140811.1-4
+- Resolves: rhbz#1307627 FTBFS
+
+* Thu Feb 04 2016 Fedora Release Engineering <releng@fedoraproject.org> - 0.20140811.1-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_24_Mass_Rebuild
+
+* Wed Jun 17 2015 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.20140811.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_23_Mass_Rebuild
+
+* Wed Oct 08 2014 Caolán McNamara <caolanm@redhat.com> - 0.20140811-1
+- bump to latest version
+
+* Wed Oct 08 2014 Caolán McNamara <caolanm@redhat.com> - 0.20121024-9
+- Resolves: rhbz#1149720 add BitTorrent as a word
+
+* Sat Jun 07 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.20121024-8
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
+
+* Mon Apr 07 2014 Caolán McNamara <caolanm@redhat.com> - 0.20121024-7
+- en-ZM different to the other locale ids
+
+* Thu Oct 24 2013 Caolán McNamara <caolanm@redhat.com> - 0.20121024-6
+- bump n-v-r to ensure rhbz#1022628 is resolved
+
+* Sat Aug 03 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.20121024-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
+
+* Fri Jul 12 2013 Caolán McNamara <caolanm@redhat.com> - 0.20121024-4
+- Resolves: rhbz#980604 wordlist tarball unreproducible, use svn export and xz
+
+* Thu Feb 14 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.20121024-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Fri Nov 02 2012 Caolán McNamara <caolanm@redhat.com> - 0.20121024-2
+- wordlist/scowl/speller/aspell/en_phonet.dat under bare LGPLv2
+
+* Wed Oct 24 2012 Caolán McNamara <caolanm@redhat.com> - 0.20121024-1
+- latest version
+- drop integrated hunspell-en-irregular-plural-possessive.patch
+
+* Thu Oct 11 2012 Caolán McNamara <caolanm@redhat.com> - 0.20110318-9
+- add possessive forms of irregular plurals for en-US, e.g. men's, women's
+
+* Mon Aug 27 2012 Caolán McNamara <caolanm@redhat.com> - 0.20110318-8
+- Related: rhbz#850709 fix requires
+
+* Mon Aug 27 2012 Caolán McNamara <caolanm@redhat.com> - 0.20110318-7
+- Resolves: rhbz#850709 allow installation of en-US and en-GB standalone
+
+* Wed Aug 1 2012 Caolán McNamara <caolanm@redhat.com> - 0.20110318-6
+- Related: rhbz#573516 we don't need hunspell to build hunspell-en
+
+* Thu Jul 19 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.20110318-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Thu Apr 12 2012 Caolán McNamara <caolanm@redhat.com> - 0.20110318-4
+- add Malawian alias
+
+* Tue Apr 10 2012 Caolán McNamara <caolanm@redhat.com> - 0.20110318-3
+- making a hames of it
+- add Zambian alias
+
+* Fri Jan 13 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.20110318-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild
+
+* Fri Mar 18 2011 Caolán McNamara <caolanm@redhat.com> - 0.20110318-1
+- latest version
+
+* Wed Feb 09 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.20110112-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_15_Mass_Rebuild
+
+* Tue Feb 08 2011 Caolán McNamara <caolanm@redhat.com> - 0.20110112-3
+- Resolves: rhbz#675550 add Haskell as a known proper noun
+
+* Thu Jan 13 2011 Caolán McNamara <caolanm@redhat.com> - 0.20110112-1
+- latest version
+
+* Sun Jan 09 2011 Caolán McNamara <caolanm@redhat.com> - 0.20110108-1
+- latest version
+
+* Tue Jan 04 2011 Caolán McNamara <caolanm@redhat.com> - 0.20110104-1
+- latest version
+
+* Tue Dec 21 2010 Caolán McNamara <caolanm@redhat.com> - 0.20101221-1
+- latest version
+
+* Tue Dec 14 2010 Caolán McNamara <caolanm@redhat.com> - 0.20101211-1
+- latest version
+
+* Wed Dec 08 2010 Caolán McNamara <caolanm@redhat.com> - 0.20101207-1
+- latest version
+
+* Fri Jul 30 2010 Caolán McNamara <caolanm@redhat.com> - 0.20100322-6
+- Resolves: rhbz#619577 add JEDEC prefixes
+
+* Fri Jul 30 2010 Caolán McNamara <caolanm@redhat.com> - 0.20100322-5
+- Resolves: rhbz#619577 add SI and IEC prefixes
+
+* Mon Jun 14 2010 Caolán McNamara <caolanm@redhat.com> - 0.20100322-4
+- Resolves: rhbz#603773 allow just non-typographical apostrophes
+
+* Sun Jun 06 2010 Caolán McNamara <caolanm@redhat.com> - 0.20100322-3
+- Resolves: rhbz#600860 generate a higher level en-US dict
+
+* Thu Apr 15 2010 Caolán McNamara <caolanm@redhat.com> - 0.20100322-2
+- allow non-typographical apostrophes
+
+* Wed Mar 31 2010 Caolán McNamara <caolanm@redhat.com> - 0.20100322-1
+- latest version
+
+* Mon Mar 08 2010 Caolán McNamara <caolanm@redhat.com> - 0.20100308-1
+- latest version
+
+* Sat Jul 25 2009 Caolán McNamara <caolanm@redhat.com> - 0.20090216-7
+- add extra mozilla REPs
+
+* Fri Jul 24 2009 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.20090216-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_12_Mass_Rebuild
+
+* Sat Jul 11 2009 Caolán McNamara <caolanm@redhat.com> - 0.20090216-5
+- tidy spec
+
+* Fri Jun 12 2009 Caolán McNamara <caolanm@redhat.com> - 0.20090216-4
+- extend coverage
+
+* Sat Jun 06 2009 Caolán McNamara <caolanm@redhat.com> - 0.20090216-3
+- Change two suspicious words with two initial capitals in en_GB
+  from ADte TEirtza to ADTe Teirtza
+
+* Tue Feb 24 2009 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.20090216-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_11_Mass_Rebuild
+
+* Mon Feb 16 2009 Caolán McNamara <caolanm@redhat.com> - 0.20090216-1
+- fix upstreamed
+
+* Mon Feb 16 2009 Caolán McNamara <caolanm@redhat.com> - 0.20090208-1
+- latest version
+
+* Wed Jan 14 2009 Caolán McNamara <caolanm@redhat.com> - 0.20090114-1
+- latest version
+
+* Sun Jan 11 2009 Caolán McNamara <caolanm@redhat.com> - 0.20090110-1
+- latest version
+
+* Thu Dec 18 2008 Caolán McNamara <caolanm@redhat.com> - 0.20081216-1
+- latest version
+
+* Sat Dec 06 2008 Caolán McNamara <caolanm@redhat.com> - 0.20081205-1
+- latest version
+
+* Tue Dec 02 2008 Caolán McNamara <caolanm@redhat.com> - 0.20081202-1
+- latest version
+
+* Sat Nov 29 2008 Caolán McNamara <caolanm@redhat.com> - 0.20081129-1
+- mozilla blog ... webmistresses signature range integrated
+
+* Thu Nov 27 2008 Caolán McNamara <caolanm@redhat.com> - 0.20081127-2
+- abbrevs are always stripped out from US/CA dicts
+- some single characters are missing from en_GB
+
+* Thu Nov 27 2008 Caolán McNamara <caolanm@redhat.com> - 0.20081127-1
+- hardcoded path dropped upstream
+
+* Tue Nov 25 2008 Caolán McNamara <caolanm@redhat.com> - 0.20081124-1
+- latest version, i.e +Barack +Obama and co.
+
+* Fri Aug 29 2008 Caolán McNamara <caolanm@redhat.com> - 0.20080829-1
+- latest version
+
+* Fri Feb 08 2008 Caolán McNamara <caolanm@redhat.com> - 0.20080207-1
+- canonical upstream source
+
+* Thu Feb 07 2008 Caolán McNamara <caolanm@redhat.com> - 0.20061130-5
+- apply mozilla word diff
+
+* Tue Jan 15 2008 Caolán McNamara <caolanm@redhat.com> - 0.20061130-4
+- clean up spec
+
+* Mon Sep 17 2007 Caolán McNamara <caolanm@redhat.com> - 0.20061130-3
+- new varient alias
+
+* Thu Aug 09 2007 Caolán McNamara <caolanm@redhat.com> - 0.20061130-2
+- clarify licence
+
+* Fri Jun 01 2007 Caolán McNamara <caolanm@redhat.com> - 0.20061130-1
+- update to latest dictionaries
+
+* Thu Feb 08 2007 Caolán McNamara <caolanm@redhat.com> - 0.20040623-2
+- update to new spec guidelines
+
+* Thu Dec 07 2006 Caolán McNamara <caolanm@redhat.com> - 0.20040623-1
+- initial version


### PR DESCRIPTION
Forgot to get a build log before turning it off, updated the Perl path and it seems to work fine.

```
[sgugshell mach@octane SPECS]$ sudo rpm -ivh ~/rpmbuild/RPMS/noarch/hunspell-en-* ~/rpmbuild/RPMS/mips/hunspell-*
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:hunspell-en-GB-0.20140811.1-16.sg################################# [ 20%]
   2:hunspell-en-US-0.20140811.1-16.sg################################# [ 40%]
   3:hunspell-1.7.0-3.sgugbeta        ################################# [ 60%]
   4:hunspell-en-0.20140811.1-16.sgugb################################# [ 80%]
   5:hunspell-devel-1.7.0-3.sgugbeta  ################################# [100%]
```