### PR TITLE
gnutls: fix libtool wrapper scripts

### DIFF
--- a/packages/gnutls/SPECS/gnutls.spec
+++ b/packages/gnutls/SPECS/gnutls.spec
@@ -134,6 +134,7 @@ make install DESTDIR=$RPM_BUILD_ROOT
 #make -C doc install-html DESTDIR=$RPM_BUILD_ROOT
 rm -f $RPM_BUILD_ROOT%{_infodir}/dir
 rm -f $RPM_BUILD_ROOT%{_libdir}/*.la
+rm -f $RPM_BUILD_ROOT%{_libdir}/*.a
 rm -f $RPM_BUILD_ROOT%{_libdir}/guile/2.2/guile-gnutls*.a
 rm -f $RPM_BUILD_ROOT%{_libdir}/guile/2.2/guile-gnutls*.la
 rm -f $RPM_BUILD_ROOT%{_libdir}/gnutls/libpkcs11mock1.*

--- a/packages/gnutls/SPECS/gnutls.spec
+++ b/packages/gnutls/SPECS/gnutls.spec
@@ -120,9 +120,13 @@ export CCASFLAGS="$CCASFLAGS -Wa,--generate-missing-build-notes=yes"
    --disable-non-suiteb-curves \
    --disable-guile \
    --with-default-trust-store-pkcs11="pkcs11:" \
-   --libdir=%{?__isa_bits==64:/usr/sgug/lib}%{!?__isa_bits==32:/usr/sgug/lib32}
+   --libdir=%{?__isa_bits==64:/usr/sgug/lib}%{!?__isa_bits==32:/usr/sgug/lib32} \
+   --prefix=/usr/sgug
 
-make 
+rm libtool
+cp /usr/sgug/bin/libtool libtool
+
+make %{?_smp_mflags} 
 
 %install
 make install DESTDIR=$RPM_BUILD_ROOT


### PR DESCRIPTION
```
[sgugshell mach@octane SPECS]$ sudo rpm -ivh ~/rpmbuild/RPMS/mips/gnutls-* --nodeps
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:gnutls-3.6.14-1.sgugbeta         ################################# [ 25%]
   2:gnutls-c++-3.6.14-1.sgugbeta     ################################# [ 50%]
   3:gnutls-devel-3.6.14-1.sgugbeta   ################################# [ 75%]
   4:gnutls-utils-3.6.14-1.sgugbeta   ################################# [100%]
[sgugshell mach@octane SPECS]$ certtool
certtool [options]
certtool --help for usage instructions.
[sgugshell mach@octane SPECS]$ certtool --version
certtool 3.6.14
Copyright (C) 2000-2020 Free Software Foundation, and others, all rights reserved.
This is free software. It is licensed for use, modification and
redistribution under the terms of the GNU General Public License,
version 3 or later <http://gnu.org/licenses/gpl.html>


Please send bug reports to:  <bugs@gnutls.org>
```

Should have checked last time, but this seems to fix it. Also passed the `smp_mflags` to make (oops!)