### PR TITLE
0.0.6 - Bug fix (shared-mime-info) and old lib retirement (nettle)

### DIFF
--- a/packages/nettle/SPECS/nettle.spec
+++ b/packages/nettle/SPECS/nettle.spec
@@ -6,7 +6,7 @@
 %global hogweed_so_ver 5
 
 # Set to 1 when building a bootstrap for a bumped so-name.
-%global bootstrap 1
+%global bootstrap 0
 
 %if 0%{?bootstrap}
 %global version_old 3.4.1rc1
@@ -18,7 +18,7 @@
 
 Name:           nettle
 Version:        3.5.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A low-level cryptographic library
 
 License:        LGPLv3+ or GPLv2+
@@ -180,6 +180,9 @@ make check
 
 
 %changelog
+* Tue Jul 21 2020 Daniel Hams <daniel.hams@gmail.com> - 3.5.1-4
+- Disable build/use of the backwards compatibility versions of libs
+
 * Sun May 31 2020 Daniel Hams <daniel.hams@gmail.com> - 3.5.1-3
 - Upgrade to fc31 version in wip (needed for new gnutls)
 

--- a/packages/shared-mime-info/SPECS/shared-mime-info.spec
+++ b/packages/shared-mime-info/SPECS/shared-mime-info.spec
@@ -1,7 +1,7 @@
 Summary: Shared MIME information database
 Name: shared-mime-info
 Version: 1.15
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: GPLv2+
 URL: http://freedesktop.org/Software/shared-mime-info
 Source0: https://gitlab.freedesktop.org/xdg/shared-mime-info/uploads/b27eb88e4155d8fccb8bb3cd12025d5b/shared-mime-info-1.15.tar.xz
@@ -79,7 +79,10 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*
 
 
 %post
-%{_bindir}/touch --no-create %{_datadir}/mime/packages &>/dev/null ||:
+if [[ ! -e %{_datadir}/mime/packages ]]; then
+  %{_bindir}/touch --no-create %{_datadir}/mime/packages &>/dev/null ||:
+fi
+update-mime-database -n %{_datadir}/mime &> /dev/null ||:
 
 # DH 06/06/2020
 # Bug in RPM means we can't currently use this
@@ -103,6 +106,9 @@ update-mime-database -n %{_datadir}/mime &> /dev/null ||:
 %{_mandir}/man*/*
 
 %changelog
+* Tue Jul 21 2020 Daniel Hams <daniel.hams@gmail.com> - 1.15-3
+- Rewrite the 'post' section to perform the initial mime lookup cache
+
 * Sun Jul 05 2020 Daniel Hams <daniel.hams@gmail.com> - 1.15-2
 - Disable the transfiletriggerin section, currently causes rpm coredump
 


### PR DESCRIPTION
shared-mime-info: Re-seen the "mime lookup cache" not created on install. A little tweak (force the compute of the cache on install) is a simple short term solution that avoids the need to re-install.

nettle: prior to 0.0.6 things had dependencies on the older version of the nettle library -> now everything is rebuilt for 0.0.6, we can retire the old compatiblity library (the regular nettle library is still there).
