### PR TITLE
Release 0.0.6 - Fixes discovered during world build #1

### DIFF
--- a/packages/docbook5-style-xsl/SPECS/docbook5-style-xsl.spec
+++ b/packages/docbook5-style-xsl/SPECS/docbook5-style-xsl.spec
@@ -3,7 +3,7 @@
 
 Name: docbook5-style-xsl
 Version: 1.79.2
-Release: 8%{?dist}
+Release: 9%{?dist}
 
 Summary: Norman Walsh's XSL stylesheets for DocBook 5.X
 
@@ -74,6 +74,9 @@ rm -rf $DESTDIR%{_datadir}/sgml/docbook/xsl-ns-stylesheets/install.sh
 perl -pi -e "s|/bin/bash|%{_bindir}/bash|g" $RPM_BUILD_ROOT%{_datadir}/sgml/docbook/xsl-ns-stylesheets-%version/tools/bin/docbook-xsl-update
 perl -pi -e "s|/usr/bin/perl|%{_bindir}/perl|g" $RPM_BUILD_ROOT%{_datadir}/sgml/docbook/xsl-ns-stylesheets-%version/fo/pdf2index
 
+# And remove a script that uses ruby we don't currently have
+rm -f $RPM_BUILD_ROOT%{_datadir}/sgml/docbook/xsl-ns-stylesheets-%version/epub/bin/dbtoepub
+
 %files
 %doc BUGS
 %doc README COPYING
@@ -123,6 +126,9 @@ if [ "$1" = 0 ]; then
 fi
 
 %changelog
+* Thu Jul 30 2020 Daniel Hams <daniel.hams@gmail.com> - 1.79.2-9
+- Remove epub translator that attempts to use ruby (we don''t have it yet)
+
 * Wed Jul 24 2019 Fedora Release Engineering <releng@fedoraproject.org> - 1.79.2-8
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
 

--- a/packages/gobject-introspection/SPECS/gobject-introspection.spec
+++ b/packages/gobject-introspection/SPECS/gobject-introspection.spec
@@ -4,7 +4,7 @@
 
 Name:           gobject-introspection
 Version:        1.62.0
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        Introspection system for GObject-based libraries
 
 License:        GPLv2+, LGPLv2+, MIT
@@ -65,6 +65,8 @@ perl -pi -e "s|/bin/sh|%{_bindir}/sh|g" giscanner/dumper.py
 
 %build
 export LD_LIBRARYN32_PATH=%{_builddir}/gobject-introspection-1.62.0/mips-sgug-irix/girepository/:$LD_LIBRARYN32_PATH
+export CC=mips-sgi-irix6.5-gcc
+export CXX=mips-sgi-irix6.5-g++
 
 %meson -Ddoctool=true -Dgtk_doc=false -Dpython=%{__python3}
 %meson_build
@@ -93,6 +95,9 @@ export LD_LIBRARYN32_PATH=%{_builddir}/gobject-introspection-1.62.0/mips-sgug-ir
 #%%{_datadir}/gtk-doc/html/gi/
 
 %changelog
+* Thu Jul 30 2020 Daniel Hams <daniel.hams@gmail.com> - 1.62.0-8
+- Be explicit about which compilers to use
+
 * Sat Jun 20 2020 Daniel Hams <daniel.hams@gmail.com> - 1.62.0-7
 - Fix some hardcoded paths + reenable deps now we have packaged enough python pieces
 

--- a/packages/pax-utils/SPECS/pax-utils.spec
+++ b/packages/pax-utils/SPECS/pax-utils.spec
@@ -6,11 +6,11 @@
 Summary: ELF utils that can check files for security relevant properties
 Name: pax-utils
 Version: 1.2.4
-Release: 7%{?dist}
+Release: 8%{?dist}
 # http://packages.gentoo.org/package/app-misc/pax-utils
 URL: https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities
 Source0: https://distfiles.gentoo.org/distfiles/%{name}-%{version}.tar.xz
-Patch0: paxutils.sgifixups.patch
+
 License: GPLv2
 BuildRequires:  gcc
 #BuildRequires: libcap-devel
@@ -34,7 +34,7 @@ PaX helpers for people interested in that.
 
 %prep
 %setup -q
-%patch0 -p1 -b .sgifixups
+
 sed -i -e 's|#!/usr/bin/python.*|#!%{_bindir}/python3|' lddtree.py
 
 %build
@@ -75,6 +75,9 @@ make check
 #%{_mandir}/man1/scanmacho.1*
 
 %changelog
+* Thu Jul 30 2020 Daniel Hams <daniel.hams@gmail.com> - 1.2.4-8
+- No longer need the patch as paths auto-fixed by rpm
+
 * Fri Apr 10 2020 Daniel Hams <daniel.hams@gmail.com> - 1.2.4-7
 - Remove hard coded shell paths
 

--- a/packages/rpm/SPECS/rpm.spec
+++ b/packages/rpm/SPECS/rpm.spec
@@ -21,7 +21,7 @@
 
 %global rpmver 4.15.0
 #global snapver rc1
-%global rel 15
+%global rel 16
 
 %global srcver %{version}%{?snapver:-%{snapver}}
 %global srcdir %{?snapver:testing}%{!?snapver:%{name}-%(echo %{version} | cut -d'.' -f1-2).x}
@@ -349,6 +349,14 @@ perl -pi -e "s|/usr/bin/sh|%{_prefix}/bin/sh|g" mkinstalldirs
 perl -pi -e "s|/bin/bash|%{_prefix}/bin/bash|g" scripts/pkgconfigdeps.sh
 perl -pi -e "s|/usr/bin/pkg-config|%{_prefix}/bin/pkg-config|g" scripts/pkgconfigdeps.sh
 
+# Rewrite some /usr/bin/env bash usages that aren''t fixed by macros (yet)
+perl -pi -e "s|/usr/bin/env bash|%{_prefix}/bin/bash|g" scripts/check-prereqs
+perl -pi -e "s|/usr/bin/env bash|%{_prefix}/bin/bash|g" scripts/check-rpaths-worker
+perl -pi -e "s|/usr/bin/env bash|%{_prefix}/bin/bash|g" scripts/find-lang.sh
+perl -pi -e "s|/usr/bin/env bash|%{_prefix}/bin/bash|g" scripts/fontconfig.prov
+perl -pi -e "s|/usr/bin/env bash|%{_prefix}/bin/bash|g" scripts/rpmdb_loadcvt
+perl -pi -e "s|/usr/bin/env bash|%{_prefix}/bin/bash|g" scripts/find-debuginfo.sh
+
 %if %{with int_bdb}
 ln -s db-%{bdbver} db
 %endif
@@ -601,6 +609,9 @@ make check || (cat tests/rpmtests.log; exit 0)
 %doc doc/librpm/html/*
 
 %changelog
+* Thu Jul 30 2020 Daniel Hams <daniel.hams@gmail.com> - 4.15.0-16
+- Rewrite some /usr/bin/env paths that aren''t fixed by macros (yet)
+
 * Mon Jun 18 2020 Daniel Hams <daniel.hams@gmail.com> - 4.15.0-15
 - Depend on newer libdicl
 

--- a/packages/sgug-rpm-config/SOURCES/sgug-etc-rpm-macros
+++ b/packages/sgug-rpm-config/SOURCES/sgug-etc-rpm-macros
@@ -63,7 +63,7 @@
 
 %_hardened_ldflags %{nil}
 
-%dist .sgugprerelease0.0.6
+%dist .sgug
 
 %_pkgdocdir %{_docdir}/%{name}
 %_docdir_fmt %%{NAME}

--- a/packages/sgug-rpm-config/SPECS/sgug-rpm-config.spec
+++ b/packages/sgug-rpm-config/SPECS/sgug-rpm-config.spec
@@ -6,8 +6,8 @@
 
 Summary: SGUG specific rpm configuration files
 Name: sgug-rpm-config
-Version: 1
-Release: 5%{?dist}
+Version: 2
+Release: 1%{?dist}
 # No version specified.
 License: GPL+
 URL: https://github.com/sgidevnet/sgug-rse/
@@ -40,6 +40,9 @@ install -p -m 644 -t %{buildroot}%{rpmetcdir} macros
 %{rpmetcdir}/macros
 
 %changelog
+* Tue Jul 28 2020 Daniel Hams <daniel.hams@gmail.com> - 2-1
+- Ready for 0.0.6
+
 * Tue Jul 14 2020 Daniel Hams <daniel.hams@gmail.com> - 1-5
 - Version bump for prerelease temporary dist
 

--- a/releasepackages.lst
+++ b/releasepackages.lst
@@ -94,7 +94,6 @@ initial-sgug
 isl
 itstool
 jasper
-jbigkit
 joe
 json-glib
 jsoncpp

--- a/releasepackages.lst
+++ b/releasepackages.lst
@@ -318,6 +318,7 @@ uuid
 vim
 wget
 which
+worker
 xcb-proto
 xhtml1-dtds
 xhtml2fo-style-xsl


### PR DESCRIPTION
During world build one, a few packages became broken due to macro changes, plus add the missing `worker` entry in releasepackages.txt.
