### PR TITLE
Make chrpath do nothing

### DIFF
--- a/packages/chrpath/SPECS/chrpath.spec
+++ b/packages/chrpath/SPECS/chrpath.spec
@@ -1,45 +1,46 @@
 Name:           chrpath
 Version:        0.16
-Release:        12%{?dist}
+Release:        14%{?dist}
 Summary:        Modify rpath of compiled programs
 
 License:        GPL+
 URL:            https://chrpath.alioth.debian.org/
-Source0:	https://alioth-archive.debian.org/releases/chrpath/chrpath/%{version}/chrpath-%{version}.tar.gz
 
-BuildRequires:  gcc
-BuildRequires: libdicl-devel >= 0.1.19
-Requires: libdicl >= 0.1.26
+#Source0:	https://alioth-archive.debian.org/releases/chrpath/chrpath/%{version}/chrpath-%{version}.tar.gz
+#BuildRequires:  gcc
+#BuildRequires: libdicl-devel >= 0.1.19
+#Requires: libdicl >= 0.1.26
 
 %description
 chrpath allows you to modify the dynamic library load path (rpath) of
 compiled programs.  Currently, only removing and modifying the rpath
 is supported.
 
-%prep
-%setup -q
+chrpath does nothing on RSE: https://github.com/sgidevnet/sgug-rse/issues/145
 
-
-%build
-export CFLAGS="-I%{_includedir}/libdicl-0.1"
-export LDFLAGS="$RPM_LD_FLAGS -ldicl-0.1 -ltinfo"
-%configure
-%make_build
-
+#%build
+#export CFLAGS="-I%{_includedir}/libdicl-0.1"
+#export LDFLAGS="$RPM_LD_FLAGS -ldicl-0.1 -ltinfo"
+#%configure
+#%make_build
 
 %install
-make install DESTDIR=%{buildroot} INSTALL="install -p"
-rm -fr %{buildroot}/usr/sgug/doc
-
+mkdir -p %{buildroot}%{_bindir}
+ln -s %{_bindir}/true %{buildroot}%{_bindir}/chrpath
+#make install DESTDIR=%{buildroot} INSTALL="install -p"
+#rm -fr %{buildroot}/usr/sgug/doc
 
 %files
-%doc AUTHORS README NEWS ChangeLog*
-%license COPYING
 %{_bindir}/chrpath
-%{_mandir}/man1/chrpath.1*
+#%doc AUTHORS README NEWS ChangeLog*
+#%license COPYING
+#%{_mandir}/man1/chrpath.1*
 
 %changelog
-* Thu Jun 18 2020 David Stancu <dstancu@nyu.edu> - 0.16-12
+* Sat Nov 14 2020 David Stancu <dstancu@nyu.edu> - 0.16-14
+- Make chrpath do nothing https://github.com/sgidevnet/sgug-rse/issues/145
+
+* Thu Jun 18 2020 David Stancu <dstancu@nyu.edu> - 0.16-13
 - Rebuilt for SGI IRIX
 - Update source URL
 


### PR DESCRIPTION
Resolves #145 

Updated the spec to symlink to `/usr/sgug/bin/true`. 

```
[sgugshell mach@octane SPECS]$ rpmbuild --clean -ba chrpath.spec
warning: Macro expanded in comment on line 9: %{version}/chrpath-%{version}.tar.gz

warning: Macro expanded in comment on line 22: %{_includedir}/libdicl-0.1"

warning: Macro expanded in comment on line 24: %configure

warning: Macro expanded in comment on line 25: %make_build

warning: Macro expanded in comment on line 37: %{_mandir}/man1/chrpath.1*

Executing(%install): /usr/sgug/bin/sh -e /usr/sgug/var/tmp/rpm-tmp.001414
+ umask 022
+ cd /usr/people/mach/rpmbuild/BUILD
+ mkdir -p /usr/people/mach/rpmbuild/BUILDROOT/chrpath-0.16-14.sgug.mips/usr/sgug/bin
+ ln -s /usr/sgug/bin/true /usr/people/mach/rpmbuild/BUILDROOT/chrpath-0.16-14.sgug.mips/usr/sgug/bin/chrpath
+ /usr/sgug/lib/rpm/check-buildroot
+ /usr/sgug/lib/rpm/brp-compress /usr/sgug
+ /usr/sgug/lib/rpm/brp-strip /usr/sgug/bin/strip
+ /usr/sgug/lib/rpm/brp-strip-comment-note /usr/sgug/bin/strip /usr/sgug/bin/objdump
+ /usr/sgug/lib/rpm/brp-strip-static-archive /usr/sgug/bin/strip
+ /usr/sgug/lib/rpm/sgug/brp-python-bytecompile /usr/sgug/bin/python 1 0
+ /usr/sgug/lib/rpm/brp-python-hardlink
+ /usr/sgug/lib/rpm/sgug/brp-mangle-shebangs
Processing files: chrpath-0.16-14.sgug.mips
warning: absolute symlink: /usr/sgug/bin/chrpath -> /usr/sgug/bin/true
Provides: chrpath = 0.16-14.sgug chrpath(mips-32) = 0.16-14.sgug
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Checking for unpackaged file(s): /usr/sgug/lib/rpm/check-files /usr/people/mach/rpmbuild/BUILDROOT/chrpath-0.16-14.sgug.mips
Wrote: /usr/people/mach/rpmbuild/SRPMS/chrpath-0.16-14.sgug.src.rpm
Wrote: /usr/people/mach/rpmbuild/RPMS/mips/chrpath-0.16-14.sgug.mips.rpm
Executing(%clean): /usr/sgug/bin/sh -e /usr/sgug/var/tmp/rpm-tmp.001414
+ umask 022
+ cd /usr/people/mach/rpmbuild/BUILD
+ /usr/sgug/bin/rm -rf /usr/people/mach/rpmbuild/BUILDROOT/chrpath-0.16-14.sgug.mips
+ RPM_EC=0
+ jobs -p
+ exit 0
Executing(--clean): /usr/sgug/bin/sh -e /usr/sgug/var/tmp/rpm-tmp.001414
+ umask 022
+ cd /usr/people/mach/rpmbuild/BUILD
+ RPM_EC=0
+ jobs -p
+ exit 0
[sgugshell mach@octane SPECS]$ sudo rpm -Uvh ~/rpmbuild/RPMS/mips/chrpath-0.16-1
chrpath-0.16-12.sgug.mips.rpm  chrpath-0.16-14.sgug.mips.rpm
[sgugshell mach@octane SPECS]$ sudo rpm -Uvh ~/rpmbuild/RPMS/mips/chrpath-0.16-14.sgug.mips.rpm
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:chrpath-0.16-14.sgug             ################################# [100%]
[sgugshell mach@octane SPECS]$ chrpath
[sgugshell mach@octane SPECS]$ echo $?
0
```