### PR TITLE
Wipnonautomated

### DIFF
--- a/packages/gtk3/SPECS/gtk3.spec
+++ b/packages/gtk3/SPECS/gtk3.spec
@@ -79,7 +79,7 @@ BuildRequires: pkgconfig(sysprof-capture-3)
 %endif
 
 # standard icons
-#Requires: adwaita-icon-theme
+Requires: adwaita-icon-theme
 # required for icon theme apis to work
 Requires: hicolor-icon-theme
 # split out in a subpackage

--- a/packages/publicsuffix-list/SPECS/publicsuffix-list.spec
+++ b/packages/publicsuffix-list/SPECS/publicsuffix-list.spec
@@ -13,8 +13,6 @@ Source2:        https://github.com/publicsuffix/list/raw/master/tests/test_psl.t
 
 BuildArch:      noarch
 
-#IRIX Note: Build this with `--without dafsa`
-
 %if %{with dafsa}
 BuildRequires:  psl-make-dafsa
 %endif

--- a/packages/sgug-rpm-tools/SPECS/sgug-rpm-tools.spec
+++ b/packages/sgug-rpm-tools/SPECS/sgug-rpm-tools.spec
@@ -9,7 +9,7 @@
 
 Summary: SGUG RPM Tools
 Name: sgug-rpm-tools
-Version: 0.1.8
+Version: 0.1.9
 Release: 1%{?dist}
 License: GPLv3+
 URL: https://github.com/sgidevnet/sgug-rpm-tools
@@ -45,6 +45,9 @@ make install DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix} INSTALL='install -p'
 %{_bindir}/sgug_world_builder
 
 %changelog
+* Sat Dec 12 2020 Daniel Hams <daniel.hams@gmail.com> - 0.1.9
+- Upgrade to 0.1.9 with sgugshell in minimal ball
+
 * Wed Dec 09 2020 Daniel Hams <daniel.hams@gmail.com> - 0.1.8
 - Upgrade to 0.1.8 which includes per-package build logs
 

--- a/packages/yelp-xsl/SPECS/yelp-xsl.spec
+++ b/packages/yelp-xsl/SPECS/yelp-xsl.spec
@@ -9,7 +9,7 @@ Source0:        https://download.gnome.org/sources/%{name}/3.34/%{name}-%{versio
 BuildArch:      noarch
 
 BuildRequires:  python3-libxml2
-#BuildRequires:  %{_bindir}/ducktype
+BuildRequires:  %{_bindir}/ducktype
 BuildRequires:  %{_bindir}/xmllint
 BuildRequires:  %{_bindir}/xsltproc
 BuildRequires:  gcc


### PR DESCRIPTION
Forgot the update to sgug-rpm-tools that has "sgugshell" in the minimal ball.

This pull request pulls that change into the 0.0.7 set.