### PR TITLE
Further clean up tweaks for 0.0.7beta + microdnf

### DIFF
--- a/packages/glib2/SOURCES/glib2.sgifixes.patch
+++ b/packages/glib2/SOURCES/glib2.sgifixes.patch
@@ -1,6 +1,6 @@
 diff -u -r glib-2.62.6-orig/gio/fam/meson.build glib-2.62.6/gio/fam/meson.build
 --- glib-2.62.6-orig/gio/fam/meson.build	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/fam/meson.build	2020-12-15 14:38:34.692710920 +0000
++++ glib-2.62.6/gio/fam/meson.build	2020-12-15 17:22:06.467833960 +0000
 @@ -7,9 +7,13 @@
  if cc.has_function('FAMNoExists', dependencies : fam_dep)
    fam_c_args += '-DHAVE_FAM_NO_EXISTS=1'
@@ -17,7 +17,7 @@ diff -u -r glib-2.62.6-orig/gio/fam/meson.build glib-2.62.6/gio/fam/meson.build
    libgio_dep,
 diff -u -r glib-2.62.6-orig/gio/glocalfile.c glib-2.62.6/gio/glocalfile.c
 --- glib-2.62.6-orig/gio/glocalfile.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/glocalfile.c	2020-12-15 14:38:34.697460120 +0000
++++ glib-2.62.6/gio/glocalfile.c	2020-12-15 17:22:06.473139640 +0000
 @@ -2826,7 +2826,7 @@
        if (g_cancellable_set_error_if_cancelled (state->cancellable, error))
          return FALSE;
@@ -38,7 +38,7 @@ diff -u -r glib-2.62.6-orig/gio/glocalfile.c glib-2.62.6/gio/glocalfile.c
      DIR *dirp;
 diff -u -r glib-2.62.6-orig/gio/gsocket.c glib-2.62.6/gio/gsocket.c
 --- glib-2.62.6-orig/gio/gsocket.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/gsocket.c	2020-12-15 14:38:34.708580040 +0000
++++ glib-2.62.6/gio/gsocket.c	2020-12-15 17:22:06.483543480 +0000
 @@ -4419,6 +4419,119 @@
  
  /* Unfortunately these have to be macros rather than inline functions due to
@@ -372,7 +372,7 @@ diff -u -r glib-2.62.6-orig/gio/gsocket.c glib-2.62.6/gio/gsocket.c
          msgvec[i].msg_len = 0;
 diff -u -r glib-2.62.6-orig/gio/gtrashportal.c glib-2.62.6/gio/gtrashportal.c
 --- glib-2.62.6-orig/gio/gtrashportal.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/gtrashportal.c	2020-12-15 14:38:34.710367000 +0000
++++ glib-2.62.6/gio/gtrashportal.c	2020-12-15 17:22:06.485299160 +0000
 @@ -86,10 +86,17 @@
  
    path = g_file_get_path (file);
@@ -393,7 +393,7 @@ diff -u -r glib-2.62.6-orig/gio/gtrashportal.c glib-2.62.6/gio/gtrashportal.c
  
 diff -u -r glib-2.62.6-orig/gio/gunixfdmessage.c glib-2.62.6/gio/gunixfdmessage.c
 --- glib-2.62.6-orig/gio/gunixfdmessage.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/gunixfdmessage.c	2020-12-15 14:38:34.711973240 +0000
++++ glib-2.62.6/gio/gunixfdmessage.c	2020-12-15 17:22:06.487075560 +0000
 @@ -48,6 +48,10 @@
  #include <fcntl.h>
  #include <errno.h>
@@ -407,7 +407,7 @@ diff -u -r glib-2.62.6-orig/gio/gunixfdmessage.c glib-2.62.6/gio/gunixfdmessage.
  #include "gnetworking.h"
 diff -u -r glib-2.62.6-orig/gio/gunixmounts.c glib-2.62.6/gio/gunixmounts.c
 --- glib-2.62.6-orig/gio/gunixmounts.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/gunixmounts.c	2020-12-15 14:38:34.717698120 +0000
++++ glib-2.62.6/gio/gunixmounts.c	2020-12-15 17:22:06.492802200 +0000
 @@ -71,6 +71,7 @@
  #include "gthemedicon.h"
  #include "gcontextspecificgroup.h"
@@ -586,7 +586,7 @@ diff -u -r glib-2.62.6-orig/gio/gunixmounts.c glib-2.62.6/gio/gunixmounts.c
    return real_dev_root;
 diff -u -r glib-2.62.6-orig/gio/tests/desktop-app-info.c glib-2.62.6/gio/tests/desktop-app-info.c
 --- glib-2.62.6-orig/gio/tests/desktop-app-info.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/tests/desktop-app-info.c	2020-12-15 14:38:34.720094040 +0000
++++ glib-2.62.6/gio/tests/desktop-app-info.c	2020-12-15 17:22:06.495193640 +0000
 @@ -80,9 +80,9 @@
  
    g_object_unref (info);
@@ -601,7 +601,7 @@ diff -u -r glib-2.62.6-orig/gio/tests/desktop-app-info.c glib-2.62.6/gio/tests/d
        res = g_app_info_can_delete (info);
 diff -u -r glib-2.62.6-orig/gio/tests/file.c glib-2.62.6/gio/tests/file.c
 --- glib-2.62.6-orig/gio/tests/file.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/tests/file.c	2020-12-15 14:38:34.723096920 +0000
++++ glib-2.62.6/gio/tests/file.c	2020-12-15 17:22:06.498233640 +0000
 @@ -989,6 +989,7 @@
                                    &num_dirs,
                                    &num_files,
@@ -612,7 +612,7 @@ diff -u -r glib-2.62.6-orig/gio/tests/file.c glib-2.62.6/gio/tests/file.c
  
 diff -u -r glib-2.62.6-orig/gio/tests/socket.c glib-2.62.6/gio/tests/socket.c
 --- glib-2.62.6-orig/gio/tests/socket.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/tests/socket.c	2020-12-15 14:38:34.726406040 +0000
++++ glib-2.62.6/gio/tests/socket.c	2020-12-15 17:22:06.501721080 +0000
 @@ -1336,10 +1336,13 @@
    gint fd;
    GError *error;
@@ -645,7 +645,7 @@ diff -u -r glib-2.62.6-orig/gio/tests/socket.c glib-2.62.6/gio/tests/socket.c
      }
 diff -u -r glib-2.62.6-orig/gio/xdgmime/xdgmime.c glib-2.62.6/gio/xdgmime/xdgmime.c
 --- glib-2.62.6-orig/gio/xdgmime/xdgmime.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/xdgmime/xdgmime.c	2020-12-15 14:38:34.728651720 +0000
++++ glib-2.62.6/gio/xdgmime/xdgmime.c	2020-12-15 17:22:06.503995880 +0000
 @@ -235,7 +235,7 @@
    xdg_data_dirs = getenv ("XDG_DATA_DIRS");
  
@@ -657,7 +657,7 @@ diff -u -r glib-2.62.6-orig/gio/xdgmime/xdgmime.c glib-2.62.6/gio/xdgmime/xdgmim
    if (xdg_data_home != NULL || home != NULL)
 diff -u -r glib-2.62.6-orig/glib/gcharset.c glib-2.62.6/glib/gcharset.c
 --- glib-2.62.6-orig/glib/gcharset.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gcharset.c	2020-12-15 14:38:34.730709800 +0000
++++ glib-2.62.6/glib/gcharset.c	2020-12-15 17:22:06.506063240 +0000
 @@ -407,7 +407,7 @@
    if (g_once_init_enter (&alias_table))
      {
@@ -669,7 +669,7 @@ diff -u -r glib-2.62.6-orig/glib/gcharset.c glib-2.62.6/glib/gcharset.c
  
 diff -u -r glib-2.62.6-orig/glib/giounix.c glib-2.62.6/glib/giounix.c
 --- glib-2.62.6-orig/glib/giounix.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/giounix.c	2020-12-15 14:38:34.732593640 +0000
++++ glib-2.62.6/glib/giounix.c	2020-12-15 17:22:06.508005320 +0000
 @@ -31,7 +31,17 @@
  
  #include "config.h"
@@ -690,7 +690,7 @@ diff -u -r glib-2.62.6-orig/glib/giounix.c glib-2.62.6/glib/giounix.c
  #include <sys/stat.h>
 diff -u -r glib-2.62.6-orig/glib/glibconfig.h.in glib-2.62.6/glib/glibconfig.h.in
 --- glib-2.62.6-orig/glib/glibconfig.h.in	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/glibconfig.h.in	2020-12-15 14:38:34.734064520 +0000
++++ glib-2.62.6/glib/glibconfig.h.in	2020-12-15 17:22:06.509469560 +0000
 @@ -16,7 +16,7 @@
   * system printf functions.  This is useful to know, for example,
   * when using glibc's register_printf_function().
@@ -702,7 +702,7 @@ diff -u -r glib-2.62.6-orig/glib/glibconfig.h.in glib-2.62.6/glib/glibconfig.h.i
  #mesondefine GOBJECT_STATIC_COMPILATION
 diff -u -r glib-2.62.6-orig/glib/gmain.c glib-2.62.6/glib/gmain.c
 --- glib-2.62.6-orig/glib/gmain.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gmain.c	2020-12-15 14:38:34.741945400 +0000
++++ glib-2.62.6/glib/gmain.c	2020-12-15 17:22:06.516661560 +0000
 @@ -2844,7 +2844,11 @@
    struct timespec ts;
    gint result;
@@ -717,7 +717,7 @@ diff -u -r glib-2.62.6-orig/glib/gmain.c glib-2.62.6/glib/gmain.c
      g_error ("GLib requires working CLOCK_MONOTONIC");
 diff -u -r glib-2.62.6-orig/glib/gmessages.c glib-2.62.6/glib/gmessages.c
 --- glib-2.62.6-orig/glib/gmessages.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gmessages.c	2020-12-15 14:38:34.749067240 +0000
++++ glib-2.62.6/glib/gmessages.c	2020-12-15 17:22:06.521531320 +0000
 @@ -1053,9 +1053,11 @@
      }
    else
@@ -734,7 +734,7 @@ diff -u -r glib-2.62.6-orig/glib/gmessages.c glib-2.62.6/glib/gmessages.c
        else
 diff -u -r glib-2.62.6-orig/glib/gnulib/fpucw.h glib-2.62.6/glib/gnulib/fpucw.h
 --- glib-2.62.6-orig/glib/gnulib/fpucw.h	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gnulib/fpucw.h	2020-12-15 14:38:34.751458600 +0000
++++ glib-2.62.6/glib/gnulib/fpucw.h	2020-12-15 17:22:06.523251080 +0000
 @@ -88,6 +88,36 @@
  # define END_LONG_DOUBLE_ROUNDING() \
    SET_FPUCW (oldcw)
@@ -774,7 +774,7 @@ diff -u -r glib-2.62.6-orig/glib/gnulib/fpucw.h glib-2.62.6/glib/gnulib/fpucw.h
  typedef unsigned int fpucw_t;
 diff -u -r glib-2.62.6-orig/glib/gnulib/meson.build glib-2.62.6/glib/gnulib/meson.build
 --- glib-2.62.6-orig/glib/gnulib/meson.build	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gnulib/meson.build	2020-12-15 14:38:34.753090920 +0000
++++ glib-2.62.6/glib/gnulib/meson.build	2020-12-15 17:22:06.524822760 +0000
 @@ -323,14 +323,16 @@
                           output: 'gnulib_math.h',
                           configuration: math_h_config)
@@ -801,7 +801,7 @@ diff -u -r glib-2.62.6-orig/glib/gnulib/meson.build glib-2.62.6/glib/gnulib/meso
  
 diff -u -r glib-2.62.6-orig/glib/gnulib/vasnprintf.c glib-2.62.6/glib/gnulib/vasnprintf.c
 --- glib-2.62.6-orig/glib/gnulib/vasnprintf.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gnulib/vasnprintf.c	2020-12-15 14:38:34.762530440 +0000
++++ glib-2.62.6/glib/gnulib/vasnprintf.c	2020-12-15 17:22:06.533635320 +0000
 @@ -3072,7 +3072,7 @@
                          int sign = 0;
                          DECL_LONG_DOUBLE_ROUNDING
@@ -811,9 +811,24 @@ diff -u -r glib-2.62.6-orig/glib/gnulib/vasnprintf.c glib-2.62.6/glib/gnulib/vas
  
                          if (signbit (arg)) /* arg < 0.0L or negative zero */
                            {
+diff -u -r glib-2.62.6-orig/glib/goption.c glib-2.62.6/glib/goption.c
+--- glib-2.62.6-orig/glib/goption.c	2020-03-18 13:16:11.000000000 +0000
++++ glib-2.62.6/glib/goption.c	2020-12-15 17:22:28.804163640 +0000
+@@ -865,7 +865,11 @@
+   if (context->help_enabled ||
+       (context->main_group && context->main_group->n_entries > 0) ||
+       context->groups != NULL)
++#if defined(__sgi)
++    g_string_append_printf (string, " %s", _("[OPTION.]"));
++#else
+     g_string_append_printf (string, " %s", _("[OPTION…]"));
++#endif
+ 
+   if (rest_description)
+     {
 diff -u -r glib-2.62.6-orig/glib/gspawn.c glib-2.62.6/glib/gspawn.c
 --- glib-2.62.6-orig/glib/gspawn.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gspawn.c	2020-12-15 14:38:34.766807320 +0000
++++ glib-2.62.6/glib/gspawn.c	2020-12-15 17:22:06.537967720 +0000
 @@ -1626,7 +1626,6 @@
    if (!intermediate_child && working_directory == NULL && !close_descriptors &&
        !search_path_from_envp && child_setup == NULL)
@@ -833,7 +848,7 @@ diff -u -r glib-2.62.6-orig/glib/gspawn.c glib-2.62.6/glib/gspawn.c
                 !close_descriptors ? "" : "(fd close requested) ",
 diff -u -r glib-2.62.6-orig/glib/gthread-posix.c glib-2.62.6/glib/gthread-posix.c
 --- glib-2.62.6-orig/glib/gthread-posix.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gthread-posix.c	2020-12-15 14:38:34.769662520 +0000
++++ glib-2.62.6/glib/gthread-posix.c	2020-12-15 17:22:06.540826360 +0000
 @@ -661,7 +661,7 @@
  
    pthread_condattr_init (&attr);
@@ -868,7 +883,7 @@ diff -u -r glib-2.62.6-orig/glib/gthread-posix.c glib-2.62.6/glib/gthread-posix.
     * monotonic, so if we're in this branch, timedwait() will already be
 diff -u -r glib-2.62.6-orig/glib/gtimezone.c glib-2.62.6/glib/gtimezone.c
 --- glib-2.62.6-orig/glib/gtimezone.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gtimezone.c	2020-12-15 14:38:34.772992680 +0000
++++ glib-2.62.6/glib/gtimezone.c	2020-12-15 17:22:06.544204520 +0000
 @@ -416,7 +416,8 @@
  
    tzdir = getenv ("TZDIR");
@@ -881,7 +896,7 @@ diff -u -r glib-2.62.6-orig/glib/gtimezone.c glib-2.62.6/glib/gtimezone.c
       if relative, it is interpreted starting from /usr/share/zoneinfo
 diff -u -r glib-2.62.6-orig/glib/gutils.c glib-2.62.6/glib/gutils.c
 --- glib-2.62.6-orig/glib/gutils.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gutils.c	2020-12-15 14:41:29.216190280 +0000
++++ glib-2.62.6/glib/gutils.c	2020-12-15 17:22:06.548662520 +0000
 @@ -992,11 +992,17 @@
        const gsize size_large = (gsize) 256 * 256;
        gchar *tmp;
@@ -996,7 +1011,7 @@ diff -u -r glib-2.62.6-orig/glib/gutils.c glib-2.62.6/glib/gutils.c
  
 diff -u -r glib-2.62.6-orig/glib/tests/collate.c glib-2.62.6/glib/tests/collate.c
 --- glib-2.62.6-orig/glib/tests/collate.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/collate.c	2020-12-15 14:38:34.779046120 +0000
++++ glib-2.62.6/glib/tests/collate.c	2020-12-15 17:22:06.550652920 +0000
 @@ -105,6 +105,172 @@
    do_collate (TRUE, TRUE, test);
  }
@@ -1181,7 +1196,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/collate.c glib-2.62.6/glib/tests/collate.
  {
 diff -u -r glib-2.62.6-orig/glib/tests/date.c glib-2.62.6/glib/tests/date.c
 --- glib-2.62.6-orig/glib/tests/date.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/date.c	2020-12-15 14:38:34.781038200 +0000
++++ glib-2.62.6/glib/tests/date.c	2020-12-15 17:22:06.552928920 +0000
 @@ -215,6 +215,11 @@
  
    g_test_bug ("793550");
@@ -1196,7 +1211,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/date.c glib-2.62.6/glib/tests/date.c
        g_test_skip ("pl_PL locale not available");
 diff -u -r glib-2.62.6-orig/glib/tests/gdatetime.c glib-2.62.6/glib/tests/gdatetime.c
 --- glib-2.62.6-orig/glib/tests/gdatetime.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/gdatetime.c	2020-12-15 14:38:34.785399080 +0000
++++ glib-2.62.6/glib/tests/gdatetime.c	2020-12-15 17:22:06.557253800 +0000
 @@ -1564,7 +1564,7 @@
    TEST_PRINTF ("%%", "%");
    TEST_PRINTF ("%", "");
@@ -1208,7 +1223,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/gdatetime.c glib-2.62.6/glib/tests/gdatet
    g_assert (GetDynamicTimeZoneInformation (&dtz_info) != TIME_ZONE_ID_INVALID);
 diff -u -r glib-2.62.6-orig/glib/tests/gvariant.c glib-2.62.6/glib/tests/gvariant.c
 --- glib-2.62.6-orig/glib/tests/gvariant.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/gvariant.c	2020-12-15 14:38:34.792377960 +0000
++++ glib-2.62.6/glib/tests/gvariant.c	2020-12-15 17:22:06.565275880 +0000
 @@ -15,6 +15,7 @@
  
  #include <glib/gvariant-internal.h>
@@ -1238,7 +1253,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/gvariant.c glib-2.62.6/glib/tests/gvarian
    g_free (res);
 diff -u -r glib-2.62.6-orig/glib/tests/protocol.c glib-2.62.6/glib/tests/protocol.c
 --- glib-2.62.6-orig/glib/tests/protocol.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/protocol.c	2020-12-15 14:38:34.793940360 +0000
++++ glib-2.62.6/glib/tests/protocol.c	2020-12-15 17:22:06.567002920 +0000
 @@ -20,6 +20,8 @@
   * if advised of the possibility of such damage.
   */
@@ -1250,7 +1265,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/protocol.c glib-2.62.6/glib/tests/protoco
  #ifdef G_OS_UNIX
 diff -u -r glib-2.62.6-orig/glib/tests/strfuncs.c glib-2.62.6/glib/tests/strfuncs.c
 --- glib-2.62.6-orig/glib/tests/strfuncs.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/strfuncs.c	2020-12-15 14:38:34.798027880 +0000
++++ glib-2.62.6/glib/tests/strfuncs.c	2020-12-15 17:22:06.571116360 +0000
 @@ -1105,7 +1105,11 @@
  {
    gchar *str_end = NULL;
@@ -1274,7 +1289,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/strfuncs.c glib-2.62.6/glib/tests/strfunc
    g_assert_true (d == g_ascii_strtod (g_ascii_dtostr (buffer, sizeof (buffer), d), NULL));
 diff -u -r glib-2.62.6-orig/gobject/tests/genmarshal.py glib-2.62.6/gobject/tests/genmarshal.py
 --- glib-2.62.6-orig/gobject/tests/genmarshal.py	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gobject/tests/genmarshal.py	2020-12-15 14:38:34.800412200 +0000
++++ glib-2.62.6/gobject/tests/genmarshal.py	2020-12-15 17:22:06.573360520 +0000
 @@ -1,4 +1,4 @@
 -#!/usr/bin/python3
 +#!/usr/sgug/bin/python3
@@ -1283,7 +1298,7 @@ diff -u -r glib-2.62.6-orig/gobject/tests/genmarshal.py glib-2.62.6/gobject/test
  # Copyright © 2019 Endless Mobile, Inc.
 diff -u -r glib-2.62.6-orig/gobject/tests/mkenums.py glib-2.62.6/gobject/tests/mkenums.py
 --- glib-2.62.6-orig/gobject/tests/mkenums.py	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gobject/tests/mkenums.py	2020-12-15 14:38:34.802031080 +0000
++++ glib-2.62.6/gobject/tests/mkenums.py	2020-12-15 17:22:06.574941320 +0000
 @@ -1,4 +1,4 @@
 -#!/usr/bin/python3
 +#!/usr/sgug/bin/python3
@@ -1292,7 +1307,7 @@ diff -u -r glib-2.62.6-orig/gobject/tests/mkenums.py glib-2.62.6/gobject/tests/m
  # Copyright © 2018 Endless Mobile, Inc.
 diff -u -r glib-2.62.6-orig/meson.build glib-2.62.6/meson.build
 --- glib-2.62.6-orig/meson.build	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/meson.build	2020-12-15 14:38:34.805518440 +0000
++++ glib-2.62.6/meson.build	2020-12-15 17:22:06.578558200 +0000
 @@ -5,7 +5,7 @@
    default_options : [
      'buildtype=debugoptimized',
@@ -1327,7 +1342,7 @@ diff -u -r glib-2.62.6-orig/meson.build glib-2.62.6/meson.build
    functions += ['statvfs']
 diff -u -r glib-2.62.6-orig/tests/mapping-test.c glib-2.62.6/tests/mapping-test.c
 --- glib-2.62.6-orig/tests/mapping-test.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/tests/mapping-test.c	2020-12-15 14:38:34.806831160 +0000
++++ glib-2.62.6/tests/mapping-test.c	2020-12-15 17:22:06.579865240 +0000
 @@ -208,7 +208,11 @@
    signal (SIGUSR1, handle_usr1);
  #endif

--- a/packages/glib2/SOURCES/glib2.sgifixes.patch
+++ b/packages/glib2/SOURCES/glib2.sgifixes.patch
@@ -1,6 +1,6 @@
 diff -u -r glib-2.62.6-orig/gio/fam/meson.build glib-2.62.6/gio/fam/meson.build
 --- glib-2.62.6-orig/gio/fam/meson.build	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/fam/meson.build	2020-12-14 02:41:15.954268000 +0000
++++ glib-2.62.6/gio/fam/meson.build	2020-12-15 14:38:34.692710920 +0000
 @@ -7,9 +7,13 @@
  if cc.has_function('FAMNoExists', dependencies : fam_dep)
    fam_c_args += '-DHAVE_FAM_NO_EXISTS=1'
@@ -17,7 +17,7 @@ diff -u -r glib-2.62.6-orig/gio/fam/meson.build glib-2.62.6/gio/fam/meson.build
    libgio_dep,
 diff -u -r glib-2.62.6-orig/gio/glocalfile.c glib-2.62.6/gio/glocalfile.c
 --- glib-2.62.6-orig/gio/glocalfile.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/glocalfile.c	2020-12-14 02:41:10.358140800 +0000
++++ glib-2.62.6/gio/glocalfile.c	2020-12-15 14:38:34.697460120 +0000
 @@ -2826,7 +2826,7 @@
        if (g_cancellable_set_error_if_cancelled (state->cancellable, error))
          return FALSE;
@@ -38,7 +38,7 @@ diff -u -r glib-2.62.6-orig/gio/glocalfile.c glib-2.62.6/gio/glocalfile.c
      DIR *dirp;
 diff -u -r glib-2.62.6-orig/gio/gsocket.c glib-2.62.6/gio/gsocket.c
 --- glib-2.62.6-orig/gio/gsocket.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/gsocket.c	2020-12-14 02:41:10.370151040 +0000
++++ glib-2.62.6/gio/gsocket.c	2020-12-15 14:38:34.708580040 +0000
 @@ -4419,6 +4419,119 @@
  
  /* Unfortunately these have to be macros rather than inline functions due to
@@ -372,7 +372,7 @@ diff -u -r glib-2.62.6-orig/gio/gsocket.c glib-2.62.6/gio/gsocket.c
          msgvec[i].msg_len = 0;
 diff -u -r glib-2.62.6-orig/gio/gtrashportal.c glib-2.62.6/gio/gtrashportal.c
 --- glib-2.62.6-orig/gio/gtrashportal.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/gtrashportal.c	2020-12-14 02:41:10.371647280 +0000
++++ glib-2.62.6/gio/gtrashportal.c	2020-12-15 14:38:34.710367000 +0000
 @@ -86,10 +86,17 @@
  
    path = g_file_get_path (file);
@@ -393,7 +393,7 @@ diff -u -r glib-2.62.6-orig/gio/gtrashportal.c glib-2.62.6/gio/gtrashportal.c
  
 diff -u -r glib-2.62.6-orig/gio/gunixfdmessage.c glib-2.62.6/gio/gunixfdmessage.c
 --- glib-2.62.6-orig/gio/gunixfdmessage.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/gunixfdmessage.c	2020-12-14 02:41:10.373319520 +0000
++++ glib-2.62.6/gio/gunixfdmessage.c	2020-12-15 14:38:34.711973240 +0000
 @@ -48,6 +48,10 @@
  #include <fcntl.h>
  #include <errno.h>
@@ -407,7 +407,7 @@ diff -u -r glib-2.62.6-orig/gio/gunixfdmessage.c glib-2.62.6/gio/gunixfdmessage.
  #include "gnetworking.h"
 diff -u -r glib-2.62.6-orig/gio/gunixmounts.c glib-2.62.6/gio/gunixmounts.c
 --- glib-2.62.6-orig/gio/gunixmounts.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/gunixmounts.c	2020-12-14 02:41:10.379403680 +0000
++++ glib-2.62.6/gio/gunixmounts.c	2020-12-15 14:38:34.717698120 +0000
 @@ -71,6 +71,7 @@
  #include "gthemedicon.h"
  #include "gcontextspecificgroup.h"
@@ -586,7 +586,7 @@ diff -u -r glib-2.62.6-orig/gio/gunixmounts.c glib-2.62.6/gio/gunixmounts.c
    return real_dev_root;
 diff -u -r glib-2.62.6-orig/gio/tests/desktop-app-info.c glib-2.62.6/gio/tests/desktop-app-info.c
 --- glib-2.62.6-orig/gio/tests/desktop-app-info.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/tests/desktop-app-info.c	2020-12-14 02:41:10.381701200 +0000
++++ glib-2.62.6/gio/tests/desktop-app-info.c	2020-12-15 14:38:34.720094040 +0000
 @@ -80,9 +80,9 @@
  
    g_object_unref (info);
@@ -601,7 +601,7 @@ diff -u -r glib-2.62.6-orig/gio/tests/desktop-app-info.c glib-2.62.6/gio/tests/d
        res = g_app_info_can_delete (info);
 diff -u -r glib-2.62.6-orig/gio/tests/file.c glib-2.62.6/gio/tests/file.c
 --- glib-2.62.6-orig/gio/tests/file.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/tests/file.c	2020-12-14 02:41:10.384716480 +0000
++++ glib-2.62.6/gio/tests/file.c	2020-12-15 14:38:34.723096920 +0000
 @@ -989,6 +989,7 @@
                                    &num_dirs,
                                    &num_files,
@@ -612,7 +612,7 @@ diff -u -r glib-2.62.6-orig/gio/tests/file.c glib-2.62.6/gio/tests/file.c
  
 diff -u -r glib-2.62.6-orig/gio/tests/socket.c glib-2.62.6/gio/tests/socket.c
 --- glib-2.62.6-orig/gio/tests/socket.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/tests/socket.c	2020-12-14 02:41:10.388054880 +0000
++++ glib-2.62.6/gio/tests/socket.c	2020-12-15 14:38:34.726406040 +0000
 @@ -1336,10 +1336,13 @@
    gint fd;
    GError *error;
@@ -645,7 +645,7 @@ diff -u -r glib-2.62.6-orig/gio/tests/socket.c glib-2.62.6/gio/tests/socket.c
      }
 diff -u -r glib-2.62.6-orig/gio/xdgmime/xdgmime.c glib-2.62.6/gio/xdgmime/xdgmime.c
 --- glib-2.62.6-orig/gio/xdgmime/xdgmime.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gio/xdgmime/xdgmime.c	2020-12-14 02:41:10.390252320 +0000
++++ glib-2.62.6/gio/xdgmime/xdgmime.c	2020-12-15 14:38:34.728651720 +0000
 @@ -235,7 +235,7 @@
    xdg_data_dirs = getenv ("XDG_DATA_DIRS");
  
@@ -657,7 +657,7 @@ diff -u -r glib-2.62.6-orig/gio/xdgmime/xdgmime.c glib-2.62.6/gio/xdgmime/xdgmim
    if (xdg_data_home != NULL || home != NULL)
 diff -u -r glib-2.62.6-orig/glib/gcharset.c glib-2.62.6/glib/gcharset.c
 --- glib-2.62.6-orig/glib/gcharset.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gcharset.c	2020-12-14 02:41:10.392505520 +0000
++++ glib-2.62.6/glib/gcharset.c	2020-12-15 14:38:34.730709800 +0000
 @@ -407,7 +407,7 @@
    if (g_once_init_enter (&alias_table))
      {
@@ -669,7 +669,7 @@ diff -u -r glib-2.62.6-orig/glib/gcharset.c glib-2.62.6/glib/gcharset.c
  
 diff -u -r glib-2.62.6-orig/glib/giounix.c glib-2.62.6/glib/giounix.c
 --- glib-2.62.6-orig/glib/giounix.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/giounix.c	2020-12-14 02:41:10.394551840 +0000
++++ glib-2.62.6/glib/giounix.c	2020-12-15 14:38:34.732593640 +0000
 @@ -31,7 +31,17 @@
  
  #include "config.h"
@@ -690,7 +690,7 @@ diff -u -r glib-2.62.6-orig/glib/giounix.c glib-2.62.6/glib/giounix.c
  #include <sys/stat.h>
 diff -u -r glib-2.62.6-orig/glib/glibconfig.h.in glib-2.62.6/glib/glibconfig.h.in
 --- glib-2.62.6-orig/glib/glibconfig.h.in	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/glibconfig.h.in	2020-12-14 02:41:10.396139520 +0000
++++ glib-2.62.6/glib/glibconfig.h.in	2020-12-15 14:38:34.734064520 +0000
 @@ -16,7 +16,7 @@
   * system printf functions.  This is useful to know, for example,
   * when using glibc's register_printf_function().
@@ -702,7 +702,7 @@ diff -u -r glib-2.62.6-orig/glib/glibconfig.h.in glib-2.62.6/glib/glibconfig.h.i
  #mesondefine GOBJECT_STATIC_COMPILATION
 diff -u -r glib-2.62.6-orig/glib/gmain.c glib-2.62.6/glib/gmain.c
 --- glib-2.62.6-orig/glib/gmain.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gmain.c	2020-12-14 02:41:10.403526080 +0000
++++ glib-2.62.6/glib/gmain.c	2020-12-15 14:38:34.741945400 +0000
 @@ -2844,7 +2844,11 @@
    struct timespec ts;
    gint result;
@@ -717,7 +717,7 @@ diff -u -r glib-2.62.6-orig/glib/gmain.c glib-2.62.6/glib/gmain.c
      g_error ("GLib requires working CLOCK_MONOTONIC");
 diff -u -r glib-2.62.6-orig/glib/gmessages.c glib-2.62.6/glib/gmessages.c
 --- glib-2.62.6-orig/glib/gmessages.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gmessages.c	2020-12-14 02:41:10.409276560 +0000
++++ glib-2.62.6/glib/gmessages.c	2020-12-15 14:38:34.749067240 +0000
 @@ -1053,9 +1053,11 @@
      }
    else
@@ -734,7 +734,7 @@ diff -u -r glib-2.62.6-orig/glib/gmessages.c glib-2.62.6/glib/gmessages.c
        else
 diff -u -r glib-2.62.6-orig/glib/gnulib/fpucw.h glib-2.62.6/glib/gnulib/fpucw.h
 --- glib-2.62.6-orig/glib/gnulib/fpucw.h	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gnulib/fpucw.h	2020-12-14 02:41:10.411098240 +0000
++++ glib-2.62.6/glib/gnulib/fpucw.h	2020-12-15 14:38:34.751458600 +0000
 @@ -88,6 +88,36 @@
  # define END_LONG_DOUBLE_ROUNDING() \
    SET_FPUCW (oldcw)
@@ -774,7 +774,7 @@ diff -u -r glib-2.62.6-orig/glib/gnulib/fpucw.h glib-2.62.6/glib/gnulib/fpucw.h
  typedef unsigned int fpucw_t;
 diff -u -r glib-2.62.6-orig/glib/gnulib/meson.build glib-2.62.6/glib/gnulib/meson.build
 --- glib-2.62.6-orig/glib/gnulib/meson.build	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gnulib/meson.build	2020-12-14 02:41:10.412828000 +0000
++++ glib-2.62.6/glib/gnulib/meson.build	2020-12-15 14:38:34.753090920 +0000
 @@ -323,14 +323,16 @@
                           output: 'gnulib_math.h',
                           configuration: math_h_config)
@@ -801,7 +801,7 @@ diff -u -r glib-2.62.6-orig/glib/gnulib/meson.build glib-2.62.6/glib/gnulib/meso
  
 diff -u -r glib-2.62.6-orig/glib/gnulib/vasnprintf.c glib-2.62.6/glib/gnulib/vasnprintf.c
 --- glib-2.62.6-orig/glib/gnulib/vasnprintf.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gnulib/vasnprintf.c	2020-12-14 02:41:10.421828640 +0000
++++ glib-2.62.6/glib/gnulib/vasnprintf.c	2020-12-15 14:38:34.762530440 +0000
 @@ -3072,7 +3072,7 @@
                          int sign = 0;
                          DECL_LONG_DOUBLE_ROUNDING
@@ -813,7 +813,7 @@ diff -u -r glib-2.62.6-orig/glib/gnulib/vasnprintf.c glib-2.62.6/glib/gnulib/vas
                            {
 diff -u -r glib-2.62.6-orig/glib/gspawn.c glib-2.62.6/glib/gspawn.c
 --- glib-2.62.6-orig/glib/gspawn.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gspawn.c	2020-12-14 02:41:10.426144560 +0000
++++ glib-2.62.6/glib/gspawn.c	2020-12-15 14:38:34.766807320 +0000
 @@ -1626,7 +1626,6 @@
    if (!intermediate_child && working_directory == NULL && !close_descriptors &&
        !search_path_from_envp && child_setup == NULL)
@@ -833,7 +833,7 @@ diff -u -r glib-2.62.6-orig/glib/gspawn.c glib-2.62.6/glib/gspawn.c
                 !close_descriptors ? "" : "(fd close requested) ",
 diff -u -r glib-2.62.6-orig/glib/gthread-posix.c glib-2.62.6/glib/gthread-posix.c
 --- glib-2.62.6-orig/glib/gthread-posix.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gthread-posix.c	2020-12-14 02:41:10.429126880 +0000
++++ glib-2.62.6/glib/gthread-posix.c	2020-12-15 14:38:34.769662520 +0000
 @@ -661,7 +661,7 @@
  
    pthread_condattr_init (&attr);
@@ -868,7 +868,7 @@ diff -u -r glib-2.62.6-orig/glib/gthread-posix.c glib-2.62.6/glib/gthread-posix.
     * monotonic, so if we're in this branch, timedwait() will already be
 diff -u -r glib-2.62.6-orig/glib/gtimezone.c glib-2.62.6/glib/gtimezone.c
 --- glib-2.62.6-orig/glib/gtimezone.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gtimezone.c	2020-12-14 02:41:10.432904480 +0000
++++ glib-2.62.6/glib/gtimezone.c	2020-12-15 14:38:34.772992680 +0000
 @@ -416,7 +416,8 @@
  
    tzdir = getenv ("TZDIR");
@@ -881,7 +881,7 @@ diff -u -r glib-2.62.6-orig/glib/gtimezone.c glib-2.62.6/glib/gtimezone.c
       if relative, it is interpreted starting from /usr/share/zoneinfo
 diff -u -r glib-2.62.6-orig/glib/gutils.c glib-2.62.6/glib/gutils.c
 --- glib-2.62.6-orig/glib/gutils.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/gutils.c	2020-12-14 02:41:10.437322400 +0000
++++ glib-2.62.6/glib/gutils.c	2020-12-15 14:41:29.216190280 +0000
 @@ -992,11 +992,17 @@
        const gsize size_large = (gsize) 256 * 256;
        gchar *tmp;
@@ -910,9 +910,93 @@ diff -u -r glib-2.62.6-orig/glib/gutils.c glib-2.62.6/glib/gutils.c
  
    data_dir_vector = g_strsplit (data_dirs, G_SEARCHPATH_SEPARATOR_S, 0);
  #else
+@@ -2323,59 +2329,59 @@
+   const struct Format formats[4][6] = {
+     {
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { KILOBYTE_FACTOR, N_("%.1f kB") },
++      { KILOBYTE_FACTOR, N_("%.1f kB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { MEGABYTE_FACTOR, N_("%.1f MB") },
++      { MEGABYTE_FACTOR, N_("%.1f MB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { GIGABYTE_FACTOR, N_("%.1f GB") },
++      { GIGABYTE_FACTOR, N_("%.1f GB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { TERABYTE_FACTOR, N_("%.1f TB") },
++      { TERABYTE_FACTOR, N_("%.1f TB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { PETABYTE_FACTOR, N_("%.1f PB") },
++      { PETABYTE_FACTOR, N_("%.1f PB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { EXABYTE_FACTOR,  N_("%.1f EB") }
++      { EXABYTE_FACTOR,  N_("%.1f EB") }
+     },
+     {
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { KIBIBYTE_FACTOR, N_("%.1f KiB") },
++      { KIBIBYTE_FACTOR, N_("%.1f KiB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { MEBIBYTE_FACTOR, N_("%.1f MiB") },
++      { MEBIBYTE_FACTOR, N_("%.1f MiB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { GIBIBYTE_FACTOR, N_("%.1f GiB") },
++      { GIBIBYTE_FACTOR, N_("%.1f GiB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { TEBIBYTE_FACTOR, N_("%.1f TiB") },
++      { TEBIBYTE_FACTOR, N_("%.1f TiB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { PEBIBYTE_FACTOR, N_("%.1f PiB") },
++      { PEBIBYTE_FACTOR, N_("%.1f PiB") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { EXBIBYTE_FACTOR, N_("%.1f EiB") }
++      { EXBIBYTE_FACTOR, N_("%.1f EiB") }
+     },
+     {
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { KILOBYTE_FACTOR, N_("%.1f kb") },
++      { KILOBYTE_FACTOR, N_("%.1f kb") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { MEGABYTE_FACTOR, N_("%.1f Mb") },
++      { MEGABYTE_FACTOR, N_("%.1f Mb") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { GIGABYTE_FACTOR, N_("%.1f Gb") },
++      { GIGABYTE_FACTOR, N_("%.1f Gb") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { TERABYTE_FACTOR, N_("%.1f Tb") },
++      { TERABYTE_FACTOR, N_("%.1f Tb") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { PETABYTE_FACTOR, N_("%.1f Pb") },
++      { PETABYTE_FACTOR, N_("%.1f Pb") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { EXABYTE_FACTOR,  N_("%.1f Eb") }
++      { EXABYTE_FACTOR,  N_("%.1f Eb") }
+     },
+     {
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { KIBIBYTE_FACTOR, N_("%.1f Kib") },
++      { KIBIBYTE_FACTOR, N_("%.1f Kib") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { MEBIBYTE_FACTOR, N_("%.1f Mib") },
++      { MEBIBYTE_FACTOR, N_("%.1f Mib") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { GIBIBYTE_FACTOR, N_("%.1f Gib") },
++      { GIBIBYTE_FACTOR, N_("%.1f Gib") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { TEBIBYTE_FACTOR, N_("%.1f Tib") },
++      { TEBIBYTE_FACTOR, N_("%.1f Tib") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { PEBIBYTE_FACTOR, N_("%.1f Pib") },
++      { PEBIBYTE_FACTOR, N_("%.1f Pib") },
+       /* Translators: Keep the no-break space between %.1f and the unit symbol */
+-      { EXBIBYTE_FACTOR, N_("%.1f Eib") }
++      { EXBIBYTE_FACTOR, N_("%.1f Eib") }
+     }
+   };
+ 
 diff -u -r glib-2.62.6-orig/glib/tests/collate.c glib-2.62.6/glib/tests/collate.c
 --- glib-2.62.6-orig/glib/tests/collate.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/collate.c	2020-12-14 02:41:10.439099840 +0000
++++ glib-2.62.6/glib/tests/collate.c	2020-12-15 14:38:34.779046120 +0000
 @@ -105,6 +105,172 @@
    do_collate (TRUE, TRUE, test);
  }
@@ -1097,7 +1181,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/collate.c glib-2.62.6/glib/tests/collate.
  {
 diff -u -r glib-2.62.6-orig/glib/tests/date.c glib-2.62.6/glib/tests/date.c
 --- glib-2.62.6-orig/glib/tests/date.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/date.c	2020-12-14 02:41:10.441048560 +0000
++++ glib-2.62.6/glib/tests/date.c	2020-12-15 14:38:34.781038200 +0000
 @@ -215,6 +215,11 @@
  
    g_test_bug ("793550");
@@ -1112,7 +1196,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/date.c glib-2.62.6/glib/tests/date.c
        g_test_skip ("pl_PL locale not available");
 diff -u -r glib-2.62.6-orig/glib/tests/gdatetime.c glib-2.62.6/glib/tests/gdatetime.c
 --- glib-2.62.6-orig/glib/tests/gdatetime.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/gdatetime.c	2020-12-14 02:41:10.445315440 +0000
++++ glib-2.62.6/glib/tests/gdatetime.c	2020-12-15 14:38:34.785399080 +0000
 @@ -1564,7 +1564,7 @@
    TEST_PRINTF ("%%", "%");
    TEST_PRINTF ("%", "");
@@ -1124,7 +1208,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/gdatetime.c glib-2.62.6/glib/tests/gdatet
    g_assert (GetDynamicTimeZoneInformation (&dtz_info) != TIME_ZONE_ID_INVALID);
 diff -u -r glib-2.62.6-orig/glib/tests/gvariant.c glib-2.62.6/glib/tests/gvariant.c
 --- glib-2.62.6-orig/glib/tests/gvariant.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/gvariant.c	2020-12-14 02:41:10.452687600 +0000
++++ glib-2.62.6/glib/tests/gvariant.c	2020-12-15 14:38:34.792377960 +0000
 @@ -15,6 +15,7 @@
  
  #include <glib/gvariant-internal.h>
@@ -1154,7 +1238,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/gvariant.c glib-2.62.6/glib/tests/gvarian
    g_free (res);
 diff -u -r glib-2.62.6-orig/glib/tests/protocol.c glib-2.62.6/glib/tests/protocol.c
 --- glib-2.62.6-orig/glib/tests/protocol.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/protocol.c	2020-12-14 02:41:10.454321520 +0000
++++ glib-2.62.6/glib/tests/protocol.c	2020-12-15 14:38:34.793940360 +0000
 @@ -20,6 +20,8 @@
   * if advised of the possibility of such damage.
   */
@@ -1166,7 +1250,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/protocol.c glib-2.62.6/glib/tests/protoco
  #ifdef G_OS_UNIX
 diff -u -r glib-2.62.6-orig/glib/tests/strfuncs.c glib-2.62.6/glib/tests/strfuncs.c
 --- glib-2.62.6-orig/glib/tests/strfuncs.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/glib/tests/strfuncs.c	2020-12-14 02:41:10.458430480 +0000
++++ glib-2.62.6/glib/tests/strfuncs.c	2020-12-15 14:38:34.798027880 +0000
 @@ -1105,7 +1105,11 @@
  {
    gchar *str_end = NULL;
@@ -1190,7 +1274,7 @@ diff -u -r glib-2.62.6-orig/glib/tests/strfuncs.c glib-2.62.6/glib/tests/strfunc
    g_assert_true (d == g_ascii_strtod (g_ascii_dtostr (buffer, sizeof (buffer), d), NULL));
 diff -u -r glib-2.62.6-orig/gobject/tests/genmarshal.py glib-2.62.6/gobject/tests/genmarshal.py
 --- glib-2.62.6-orig/gobject/tests/genmarshal.py	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gobject/tests/genmarshal.py	2020-12-14 02:41:10.460611680 +0000
++++ glib-2.62.6/gobject/tests/genmarshal.py	2020-12-15 14:38:34.800412200 +0000
 @@ -1,4 +1,4 @@
 -#!/usr/bin/python3
 +#!/usr/sgug/bin/python3
@@ -1199,7 +1283,7 @@ diff -u -r glib-2.62.6-orig/gobject/tests/genmarshal.py glib-2.62.6/gobject/test
  # Copyright © 2019 Endless Mobile, Inc.
 diff -u -r glib-2.62.6-orig/gobject/tests/mkenums.py glib-2.62.6/gobject/tests/mkenums.py
 --- glib-2.62.6-orig/gobject/tests/mkenums.py	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/gobject/tests/mkenums.py	2020-12-14 02:41:10.462180240 +0000
++++ glib-2.62.6/gobject/tests/mkenums.py	2020-12-15 14:38:34.802031080 +0000
 @@ -1,4 +1,4 @@
 -#!/usr/bin/python3
 +#!/usr/sgug/bin/python3
@@ -1208,7 +1292,7 @@ diff -u -r glib-2.62.6-orig/gobject/tests/mkenums.py glib-2.62.6/gobject/tests/m
  # Copyright © 2018 Endless Mobile, Inc.
 diff -u -r glib-2.62.6-orig/meson.build glib-2.62.6/meson.build
 --- glib-2.62.6-orig/meson.build	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/meson.build	2020-12-14 02:41:10.465624320 +0000
++++ glib-2.62.6/meson.build	2020-12-15 14:38:34.805518440 +0000
 @@ -5,7 +5,7 @@
    default_options : [
      'buildtype=debugoptimized',
@@ -1243,7 +1327,7 @@ diff -u -r glib-2.62.6-orig/meson.build glib-2.62.6/meson.build
    functions += ['statvfs']
 diff -u -r glib-2.62.6-orig/tests/mapping-test.c glib-2.62.6/tests/mapping-test.c
 --- glib-2.62.6-orig/tests/mapping-test.c	2020-03-18 13:16:11.000000000 +0000
-+++ glib-2.62.6/tests/mapping-test.c	2020-12-14 02:41:10.466905280 +0000
++++ glib-2.62.6/tests/mapping-test.c	2020-12-15 14:38:34.806831160 +0000
 @@ -208,7 +208,11 @@
    signal (SIGUSR1, handle_usr1);
  #endif

--- a/packages/glib2/SPECS/glib2.spec
+++ b/packages/glib2/SPECS/glib2.spec
@@ -8,7 +8,7 @@
 
 Name: glib2
 Version: 2.62.6
-Release: 9%{?dist}
+Release: 10%{?dist}
 Summary: A library of handy utility functions
 
 License: LGPLv2+
@@ -269,6 +269,9 @@ glib-compile-schemas %{_datadir}/glib-2.0/schemas &> /dev/null || :
 %{_datadir}/installed-tests
 
 %changelog
+* Tue Dec 15 2020 Daniel Hams <daniel.hams@gmail.com> - 2.62.6-10
+- More hardcoded UTF fixes (options in help)
+
 * Tue Dec 15 2020 Daniel Hams <daniel.hams@gmail.com> - 2.62.6-9
 - Change hardcoded use of UTF non-breaking spaces in sizing formats
 

--- a/packages/glib2/SPECS/glib2.spec
+++ b/packages/glib2/SPECS/glib2.spec
@@ -8,7 +8,7 @@
 
 Name: glib2
 Version: 2.62.6
-Release: 8%{?dist}
+Release: 9%{?dist}
 Summary: A library of handy utility functions
 
 License: LGPLv2+
@@ -269,6 +269,9 @@ glib-compile-schemas %{_datadir}/glib-2.0/schemas &> /dev/null || :
 %{_datadir}/installed-tests
 
 %changelog
+* Tue Dec 15 2020 Daniel Hams <daniel.hams@gmail.com> - 2.62.6-9
+- Change hardcoded use of UTF non-breaking spaces in sizing formats
+
 * Mon Dec 14 2020 Daniel Hams <daniel.hams@gmail.com> - 2.62.6-8
 - Fix up use of the IRIX file alteration monitor, enable fam module
 

--- a/packages/libsmartcols/SPECS/libsmartcols.spec
+++ b/packages/libsmartcols/SPECS/libsmartcols.spec
@@ -34,7 +34,7 @@ BuildRequires: zlib-devel
 BuildRequires: popt-devel
 BuildRequires: gcc
 
-BuildRequries: libdicl-devel
+BuildRequires: libdicl-devel
 
 ### Sources
 Source0: ftp://ftp.kernel.org/pub/linux/utils/util-linux/v%{upstream_major}/util-linux-%{upstream_version}.tar.xz

--- a/packages/libsolv/SOURCES/libsolv.sgifixes.patch
+++ b/packages/libsolv/SOURCES/libsolv.sgifixes.patch
@@ -1,6 +1,18 @@
+diff -u -r libsolv-0.7.14-orig/bindings/perl/CMakeLists.txt libsolv-0.7.14/bindings/perl/CMakeLists.txt
+--- libsolv-0.7.14-orig/bindings/perl/CMakeLists.txt	2020-05-27 10:55:11.000000000 +0000
++++ libsolv-0.7.14/bindings/perl/CMakeLists.txt	2020-12-16 21:22:24.267071440 +0000
+@@ -24,7 +24,7 @@
+     VERBATIM
+ )
+ 
+-ADD_DEFINITIONS(${PERL_CCFLAGS} -Wno-unused -Wno-nonnull)
++ADD_DEFINITIONS(${PERL_CCFLAGS} -Wno-unused -Wno-nonnull -fno-var-tracking)
+ LINK_DIRECTORIES (${PERL_CORE_DIR})
+ INCLUDE_DIRECTORIES (${PERL_INCLUDE_PATH} ${PERL_CORE_DIR})
+ 
 diff -u -r libsolv-0.7.14-orig/bindings/solv.i libsolv-0.7.14/bindings/solv.i
 --- libsolv-0.7.14-orig/bindings/solv.i	2020-05-27 10:55:11.000000000 +0000
-+++ libsolv-0.7.14/bindings/solv.i	2020-12-14 14:21:56.267342560 +0000
++++ libsolv-0.7.14/bindings/solv.i	2020-12-16 21:22:09.024838040 +0000
 @@ -4,6 +4,15 @@
   * on the generated c code
   */
@@ -19,7 +31,7 @@ diff -u -r libsolv-0.7.14-orig/bindings/solv.i libsolv-0.7.14/bindings/solv.i
  #ifdef SWIGRUBY
 diff -u -r libsolv-0.7.14-orig/ext/repo_products.c libsolv-0.7.14/ext/repo_products.c
 --- libsolv-0.7.14-orig/ext/repo_products.c	2020-05-27 10:55:11.000000000 +0000
-+++ libsolv-0.7.14/ext/repo_products.c	2020-12-14 14:21:56.271670720 +0000
++++ libsolv-0.7.14/ext/repo_products.c	2020-12-16 21:22:09.026788200 +0000
 @@ -11,6 +11,13 @@
   * for further information
   */
@@ -36,7 +48,7 @@ diff -u -r libsolv-0.7.14-orig/ext/repo_products.c libsolv-0.7.14/ext/repo_produ
  #include <time.h>
 diff -u -r libsolv-0.7.14-orig/ext/repo_rpmdb.c libsolv-0.7.14/ext/repo_rpmdb.c
 --- libsolv-0.7.14-orig/ext/repo_rpmdb.c	2020-05-27 10:55:11.000000000 +0000
-+++ libsolv-0.7.14/ext/repo_rpmdb.c	2020-12-14 14:22:10.259741200 +0000
++++ libsolv-0.7.14/ext/repo_rpmdb.c	2020-12-16 21:22:09.030191960 +0000
 @@ -1874,7 +1874,9 @@
    struct rpmdbstate state;
    char *payloadformat;
@@ -50,7 +62,7 @@ diff -u -r libsolv-0.7.14-orig/ext/repo_rpmdb.c libsolv-0.7.14/ext/repo_rpmdb.c
    Repodata *data;
 diff -u -r libsolv-0.7.14-orig/src/repopage.c libsolv-0.7.14/src/repopage.c
 --- libsolv-0.7.14-orig/src/repopage.c	2020-05-27 10:55:11.000000000 +0000
-+++ libsolv-0.7.14/src/repopage.c	2020-12-14 14:21:56.278612960 +0000
++++ libsolv-0.7.14/src/repopage.c	2020-12-16 21:22:09.032614040 +0000
 @@ -18,6 +18,13 @@
   * pages automatically get dropped.
   */

--- a/packages/libsolv/SPECS/libsolv.spec
+++ b/packages/libsolv/SPECS/libsolv.spec
@@ -27,7 +27,7 @@
 
 Name:           lib%{libname}
 Version:        0.7.14
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Package dependency solver
 
 License:        BSD
@@ -181,9 +181,8 @@ export CFLAGS="-I%{_includedir}/libdicl-0.1 -D_SGI_SOURCE -D_SGI_MP_SOURCE -D_SG
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-ldicl-0.1 -ldiclfunopen-0.1"
 %else
-# We only use O2 - O3 causes a _very_ long compilation (perl bindings)
-#export CFLAGS="-I%{_includedir}/libdicl-0.1 -D_SGI_SOURCE -D_SGI_REENTRANT_FUNCTIONS -DLIBDICL_NEED_FUNOPEN $RPM_OPT_FLAGS"
-export CFLAGS="-I%{_includedir}/libdicl-0.1 -D_SGI_SOURCE -D_SGI_MP_SOURCE -D_SGI_REENTRANT_FUNCTIONS -DLIBDICL_NEED_FUNOPEN -g -O2"
+export CFLAGS="-I%{_includedir}/libdicl-0.1 -D_SGI_SOURCE -D_SGI_REENTRANT_FUNCTIONS -DLIBDICL_NEED_FUNOPEN $RPM_OPT_FLAGS"
+export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-ldicl-0.1 -ldiclfunopen-0.1 $RPM_LD_FLAGS"
 %endif
 
@@ -323,6 +322,9 @@ export LD_LIBRARYN32_PATH=$TEST_LIB_ROOT/src:$TEST_LIB_ROOT/ext:$TEST_LIB_ROOT/b
 %endif
 
 %changelog
+* Wed Dec 16 2020 Daniel Hams <daniel.hams@gmail.com> - 0.7.14-4
+- Enable O3 by passing -fno-var-tracking to disable gcc var tracking
+
 * Mon Dec 14 2020 Daniel Hams <daniel.hams@gmail.com> - 0.7.14-3
 - Rewrite some hardcoded paths to rpm db
 

--- a/packages/microdnf/SPECS/microdnf.spec
+++ b/packages/microdnf/SPECS/microdnf.spec
@@ -8,7 +8,7 @@
 
 Name:           microdnf
 Version:        3.4.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Minimal C implementation of DNF tweaked for IRIX
 
 License:        GPLv3+
@@ -31,6 +31,8 @@ BuildRequires:  libsolv-devel >= 0.7.14-3
 BuildRequires:  glib2 >= 2.62.6-8
 
 Requires:       libdnf%{?_isa} >= %{libdnf_version}
+
+Requires:       glib2-fam
 
 %description
 Micro DNF is a very minimal C implementation of DNFs install, upgrade,
@@ -78,6 +80,9 @@ export LDFLAGS="-ldicl-0.1 $RPM_LD_FLAGS"
 %{_bindir}/%{name}
 
 %changelog
+* Tue Dec 15 2020 Daniel Hams <daniel.hams@gmail.com> - 3.4.0-4
+- Include dependency on glib2-fam for file/dir monitoring
+
 * Mon Dec 14 2020 Daniel Hams <daniel.hams@gmail.com> - 3.4.0-3
 - Depend on necessary smartcols, libsolv, glib2 versions
 

--- a/packages/sgug-rpm-tools/SPECS/sgug-rpm-tools.spec
+++ b/packages/sgug-rpm-tools/SPECS/sgug-rpm-tools.spec
@@ -9,7 +9,7 @@
 
 Summary: SGUG RPM Tools
 Name: sgug-rpm-tools
-Version: 0.1.9
+Version: 0.2.1
 Release: 1%{?dist}
 License: GPLv3+
 URL: https://github.com/sgidevnet/sgug-rpm-tools
@@ -45,6 +45,12 @@ make install DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix} INSTALL='install -p'
 %{_bindir}/sgug_world_builder
 
 %changelog
+* Tue Dec 15 2020 Daniel Hams <daniel.hams@gmail.com> - 0.2.1
+- Upgrade to 0.2.1 with libiconv, openssh clients too
+
+* Tue Dec 15 2020 Daniel Hams <daniel.hams@gmail.com> - 0.2.0
+- Upgrade to 0.2.0 with sgugrse repo packages in ball
+
 * Sat Dec 12 2020 Daniel Hams <daniel.hams@gmail.com> - 0.1.9
 - Upgrade to 0.1.9 with sgugshell in minimal ball
 

--- a/packages/sgugrse-release/SPECS/sgugrse-release.spec
+++ b/packages/sgugrse-release/SPECS/sgugrse-release.spec
@@ -1,16 +1,16 @@
-%define release_name Double O Seven
-%define dist_version 0.0.7alpha
-%define bug_version 0.0.7alpha
+%define release_name Miss Moneypenny
+%define dist_version 0.0.7beta
+%define bug_version 0.0.7beta
 
 # Change this when branching to fNN
-%define doc_version 0.0.7alpha
+%define doc_version 0.0.7beta
 
 # The package can only be built by a very small number of people
 # if you are not sure you can build it do not attempt to
 
 Summary:        SGUG RSE release files
 Name:           sgugrse-release
-Version:        0.0.7alpha
+Version:        0.0.7beta
 Release:        1
 License:        MIT
 URL:            https://sgi.sh/
@@ -62,7 +62,7 @@ Obsoletes:  sgug-release < 0.0.6beta
 Provides:   sgug-release
 Obsoletes:  sgugrse-release < 0.0.6beta
 
-Requires:   sgugrse-repos(%{version}) >= 0.0.6beta
+Requires:   sgugrse-repos(%{version}) >= 0.0.7beta
 
 %description common
 Release files common to all Editions and Spins of SGUG RSE
@@ -71,8 +71,6 @@ Release files common to all Editions and Spins of SGUG RSE
 #sed -i 's|@@VERSION@@|%{dist_version}|g' %{SOURCE2}
 
 %build
-
-perl -pi -e "s|||g" blah
 
 %install
 rm -rf %{buildroot}/*
@@ -206,6 +204,9 @@ ln -s %{_swidtagdir} %{buildroot}%{_sysconfdir}/swid/swidtags.d/sgugrseproject.o
 %{_prefix}/lib/os-release
 
 %changelog
+* Wed Dec 16 2020 Daniel Hams <daniel.hams@gmail.com> - 0.0.7beta-1
+- Setting correct release version
+
 * Tue Nov 10 2020 Daniel Hams <daniel.hams@gmail.com> - 0.0.7alpha-1
 - Building up the support infra for microdnf
 

--- a/packages/sgugrse-repos/SOURCES/sgugrse-updates-testing.repo
+++ b/packages/sgugrse-repos/SOURCES/sgugrse-updates-testing.repo
@@ -2,7 +2,7 @@
 name=Sgugrse $releasever - $basearch - Test Updates
 baseurl=http://sgugrse.s3-website.us-east-2.amazonaws.com/pub/sgugrse/irix/updates/testing/$releasever/Everything/$basearch/
 #metalink=https://mirrors.sgugrsetest.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
-enabled=0
+enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=0

--- a/packages/sgugrse-repos/SOURCES/sgugrse-updates.repo
+++ b/packages/sgugrse-repos/SOURCES/sgugrse-updates.repo
@@ -2,7 +2,7 @@
 name=Sgugrse $releasever - $basearch - Updates
 baseurl=http://sgugrse.s3-website.us-east-2.amazonaws.com/pub/sgugrse/irix/updates/$releasever/Everything/$basearch/
 #metalink=https://mirrors.sgugrsetest.org/metalink?repo=updates-released-f$releasever&arch=$basearch
-enabled=0
+enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=0

--- a/packages/sgugrse-repos/SOURCES/sgugrse.repo
+++ b/packages/sgugrse-repos/SOURCES/sgugrse.repo
@@ -24,7 +24,7 @@ skip_if_unavailable=False
 
 [sgugrse-source]
 name=Sgugrse $releasever - Source
-baseurl=http://sgugrse.s3-website.us-east-2.amazonaws.com/pub/sgugrse/irix/releases/$releasever/Everything/source/tree/
+baseurl=http://sgugrse.s3-website.us-east-2.amazonaws.com/pub/sgugrse/irix/releases/$releasever/Everything/SRPMS/
 #metalink=https://mirrors.sgugrsetest.org/metalink?repo=sgugrse-source-$releasever&arch=$basearch
 enabled=0
 metadata_expire=7d

--- a/packages/sgugrse-repos/SPECS/sgugrse-repos.spec
+++ b/packages/sgugrse-repos/SPECS/sgugrse-repos.spec
@@ -1,7 +1,7 @@
 Summary:        Sgugrse package repositories
 Name:           sgugrse-repos
-Version:        0.0.7alpha
-Release:        2%{?_module_build:%{?dist}}
+Version:        0.0.7beta
+Release:        1%{?_module_build:%{?dist}}
 License:        MIT
 URL:            https://sgugrseproject.org/
 
@@ -65,8 +65,8 @@ cd $PREV_WD
 
 install -d -m 755 $RPM_BUILD_ROOT/usr/sgug/etc/yum.repos.d
 install -m 644 %{_sourcedir}/sgugrse.repo $RPM_BUILD_ROOT/usr/sgug/etc/yum.repos.d
-#install -m 644 %{_sourcedir}/sgugrse-updates.repo $RPM_BUILD_ROOT/usr/sgug/etc/yum.repos.d
-#install -m 644 %{_sourcedir}/sgugrse-updates-testing.repo $RPM_BUILD_ROOT/usr/sgug/etc/yum.repos.d
+install -m 644 %{_sourcedir}/sgugrse-updates.repo $RPM_BUILD_ROOT/usr/sgug/etc/yum.repos.d
+install -m 644 %{_sourcedir}/sgugrse-updates-testing.repo $RPM_BUILD_ROOT/usr/sgug/etc/yum.repos.d
 
 # Install ostree remote config
 install -d -m 755 $RPM_BUILD_ROOT/usr/sgug/etc/ostree/remotes.d/
@@ -75,8 +75,8 @@ install -m 644 %{_sourcedir}/sgugrse.conf $RPM_BUILD_ROOT/usr/sgug/etc/ostree/re
 %files
 %dir /usr/sgug/etc/yum.repos.d
 %config(noreplace) /usr/sgug/etc/yum.repos.d/sgugrse.repo
-#%%config(noreplace) /usr/sgug/etc/yum.repos.d/sgugrse-updates.repo
-#%%config(noreplace) /usr/sgug/etc/yum.repos.d/sgugrse-updates-testing.repo
+%config(noreplace) /usr/sgug/etc/yum.repos.d/sgugrse-updates.repo
+%config(noreplace) /usr/sgug/etc/yum.repos.d/sgugrse-updates-testing.repo
 
 %files -n sgugrse-gpg-keys
 %dir /usr/sgug/etc/pki/rpm-gpg
@@ -88,6 +88,9 @@ install -m 644 %{_sourcedir}/sgugrse.conf $RPM_BUILD_ROOT/usr/sgug/etc/ostree/re
 /usr/sgug/etc/ostree/remotes.d/sgugrse.conf
 
 %changelog
+* Wed Dec 16 2020 Daniel Hams <daniel.hams@gmail.com> - 0.0.7beta-1
+- Enable update and test update repos
+
 * Mon Dec 14 2020 Daniel Hams <daniel.hams@gmail.com> - 0.0.7alpha-2
 - Enable a single repository while we are testing, disable gpg checking for now.
 


### PR DESCRIPTION
Ensure we have libiconv, openssh-clients + sgugrse-repos in the minimal ball (sgug-rpm-tools)

Fix the formatting of package sizes in microdnf with fix in glib2

Ensure microdnf requires glib2-fam for directory/file monitoring

Bug fix to libsmartcols typo.