### PR TITLE
Shim to quietly skip ldconfig-type  macros in specs during rpmbuild

### DIFF
--- a/packages/sgug-rpm-config/SOURCES/macros.ldconfig
+++ b/packages/sgug-rpm-config/SOURCES/macros.ldconfig
@@ -1,0 +1,7 @@
+%ldconfig /usr/sgug/bin/echo
+%ldconfig_post(n:) /usr/sgug/bin/echo
+%ldconfig_postun(n:) /usr/sgug/bin/echo
+%ldconfig_scriptlets(n:) %{?ldconfig:\
+%ldconfig_post /usr/sgug/bin/echo \
+%ldconfig_postun /usr/sgug/bin/echo }\
+}

--- a/packages/sgug-rpm-config/SPECS/sgug-rpm-config.spec
+++ b/packages/sgug-rpm-config/SPECS/sgug-rpm-config.spec
@@ -40,7 +40,7 @@ Source103: macros.nodejs-srpm
 #Source151: macros.kmp
 Source152: macros.vpath
 Source153: macros.forge
-#Source154: macros.ldconfig
+Source154: macros.ldconfig
 Source155: macros.sgugrse-misc
 
 # Build policy scripts
@@ -196,7 +196,7 @@ install -p -m 644 -T sgug-etc-rpm-macros %{buildroot}%{rpmetcdir}/macros
 %{_rpmconfigdir}/macros.d/macros.*-srpm
 #%%{_rpmconfigdir}/macros.d/macros.dwz
 %{_rpmconfigdir}/macros.d/macros.forge
-#%%{_rpmconfigdir}/macros.d/macros.ldconfig
+%{_rpmconfigdir}/macros.d/macros.ldconfig
 %{_rpmconfigdir}/macros.d/macros.vpath
 %{_rpmconfigdir}/macros.d/macros.sgugrse-misc
 %dir %{_rpmluadir}/sgugrse


### PR DESCRIPTION
This restores macros.d/macros.ldconfig , but only runs 'echo' when invoked.

Tested to not interfere with builds.