### PR TITLE
Fix up openssh-server to automatically set itself up

### DIFF
--- a/packages/openssh/SOURCES/openssh.sgifixes2.patch
+++ b/packages/openssh/SOURCES/openssh.sgifixes2.patch
@@ -1,0 +1,73 @@
+--- openssh-8.1p1/sshd_config.sgiorig	2021-11-07 23:25:58.075216641 +0000
++++ openssh-8.1p1/sshd_config	2021-11-07 23:26:52.700646588 +0000
+@@ -3,7 +3,7 @@
+ # This is the sshd server system-wide configuration file.  See
+ # sshd_config(5) for more information.
+ 
+-# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
++# This sshd was compiled with PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
+ 
+ # The strategy used for options in the default sshd_config shipped with
+ # OpenSSH is to specify options with their default value where
+@@ -34,10 +34,10 @@
+ # To opt out, uncomment a line with redefinition of  CRYPTO_POLICY=
+ # variable in  /etc/sysconfig/sshd  to overwrite the policy.
+ # For more information, see manual page for update-crypto-policies(8).
++Ciphers 3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com
+ 
+ # Logging
+-#SyslogFacility AUTH
+-SyslogFacility AUTHPRIV
++SyslogFacility AUTH
+ #LogLevel INFO
+ 
+ # Authentication:
+@@ -59,7 +59,7 @@
+ #AuthorizedKeysCommand none
+ #AuthorizedKeysCommandUser nobody
+ 
+-# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
++# For this to work you will also need host keys in /usr/sgug/etc/ssh/ssh_known_hosts
+ #HostbasedAuthentication no
+ # Change to yes if you don't trust ~/.ssh/known_hosts for
+ # HostbasedAuthentication
+@@ -68,9 +68,8 @@
+ #IgnoreRhosts yes
+ 
+ # To disable tunneled clear text passwords, change to no here!
+-#PasswordAuthentication yes
+-#PermitEmptyPasswords no
+ PasswordAuthentication yes
++PermitEmptyPasswords no
+ 
+ # Change to no to disable s/key passwords
+ #ChallengeResponseAuthentication yes
+@@ -83,8 +82,8 @@
+ #KerberosGetAFSToken no
+ 
+ # GSSAPI options
+-GSSAPIAuthentication yes
+-GSSAPICleanupCredentials no
++#GSSAPIAuthentication yes
++#GSSAPICleanupCredentials no
+ 
+ # Set this to 'yes' to enable PAM authentication, account processing,
+ # and session processing. If this is enabled, PAM authentication will
+@@ -95,7 +94,7 @@
+ # If you just want the PAM account and session checks to run without
+ # PAM authentication, then enable this but set PasswordAuthentication
+ # and ChallengeResponseAuthentication to 'no'.
+-UsePAM yes
++#UsePAM no
+ 
+ #AllowAgentForwarding yes
+ #AllowTcpForwarding yes
+@@ -132,7 +131,7 @@
+ AcceptEnv XMODIFIERS
+ 
+ # override default of no subsystems
+-Subsystem	sftp	/usr/libexec/sftp-server
++Subsystem	sftp	/usr/sgug/libexec/openssh/sftp-server
+ 
+ # Example of overriding settings on a per-user basis
+ #Match User anoncvs

--- a/packages/openssh/SOURCES/sgug-sshd
+++ b/packages/openssh/SOURCES/sgug-sshd
@@ -1,0 +1,101 @@
+#!/bin/sh
+##
+## Start or stop the sshd daemon, new version from SGUG
+##
+
+IS_ON=/etc/chkconfig
+SSHD=/usr/sgug/sbin/sshd
+KEYGEN=/usr/sgug/bin/ssh-keygen
+
+
+RSA_KEY=/usr/sgug/etc/ssh/ssh_host_rsa_key
+ECDSA_KEY=/usr/sgug/etc/ssh/ssh_host_ecdsa_key
+DSA_KEY=/usr/sgug/etc/ssh/ssh_host_ed25519_key
+
+# At some point fix privilege separation
+USE_PRIV_SEP=
+CSU="/sbin/suattr"
+CAP_SSH="CAP_DAC_READ_SEARCH,CAP_DEVICE_MGT,CAP_PRIV_PORT,CAP_DAC_WRITE,CAP_SETUID,CAP_SETGID,CAP_FOWNER,CAP_AUDIT_CONTROL,CAP_CHROOT,CAP_MAC_WRITE+ep CAP_NETWORK_MGT,CAP_MAC_UPGRADE,CAP_MAC_RELABEL_SUBJ,CAP_SETPCAP,CAP_AUDIT_WRITE,CAP_MAC_DOWNGRADE,CAP_MAC_RELABEL_OPEN,CAP_MAC_MLD+p"
+
+if $IS_ON verbose; then
+    ECHO=echo
+else
+    ECHO=:
+fi
+
+do_hostkeygen()
+{
+	# Always be verbose here
+	if [ ! -s $ECDSA_KEY ]; then
+		"Generating $ECDSA_KEY: "
+		$KEYGEN -t ecdsa -f $ECDSA_KEY -N '' > /dev/null 2>&1
+	fi
+	if [ ! -s $RSA_KEY ]; then
+		"Generating $RSA_KEY: "
+		$KEYGEN -t rsa -b 1024 -f $RSA_KEY -N '' > /dev/null 2>&1
+	fi
+	if [ ! -s $DSA_KEY ]; then
+		"Generating $DSA_KEY: "
+		$KEYGEN -t ed25519 -f $DSA_KEY -N '' > /dev/null 2>&1
+	fi
+}
+
+kill_sshd()
+{
+	if [ -r /var/run/sshd.pid ]; then
+	    sshd_pid=`cat /var/run/sshd.pid`
+	    ps -p $sshd_pid | grep sshd > /dev/null
+	    if [ $? -eq 0 ]; then
+		/usr/bin/kill -15 -$sshd_pid
+	    fi
+	fi
+}
+
+start_sshd()
+{
+	if $IS_ON sshd; then
+	    echo "sgug-sshd: can't have both sshd and sgug-sshd enabled due to both wanting pid file"
+	    exit 1
+	fi
+	if $IS_ON sgug-sshd && test -x $SSHD; then
+	    $ECHO "Starting sshd:\c"
+	    do_hostkeygen
+
+	    if [ "$USE_PRIV_SEP" != "" ] ; then
+		$CSU -C "$CAP_SSH" -c $SSHD
+	    else
+		$SSHD
+	    fi
+	    $ECHO "."
+	fi
+}
+
+case "$1" in
+    start)
+	kill_sshd
+	start_sshd
+	;;
+
+    restart)
+	kill_sshd
+	start_sshd
+	;;
+
+    stop)
+	$ECHO "Stopping sshd."
+	kill_sshd
+	exit 0
+	;;
+
+    stop-all)
+	$ECHO "Stopping sshd and logins."
+	kill_sshd
+	killall -15 sshd
+	exit 0
+	;;
+
+    *)
+	echo "usage: $0 {start|stop|stop-all|restart}"
+	;;
+esac
+

--- a/packages/openssh/SPECS/openssh.spec
+++ b/packages/openssh/SPECS/openssh.spec
@@ -66,7 +66,7 @@
 
 # Do not forget to bump pam_ssh_agent_auth release if you rewind the main package release to 1
 %global openssh_ver 8.1p1
-%global openssh_rel 11
+%global openssh_rel 12
 %global pam_ssh_agent_ver 0.10.3
 %global pam_ssh_agent_rel 7
 
@@ -83,14 +83,16 @@ Source3: DJM-GPG-KEY.gpg
 #Source4: http://prdownloads.sourceforge.net/pamsshagentauth/pam_ssh_agent_auth/pam_ssh_agent_auth-%{pam_ssh_agent_ver}.tar.bz2
 #Source5: pam_ssh_agent-rmheaders
 #Source6: ssh-keycat.pam
-Source7: sshd.sysconfig
+#Source7: sshd.sysconfig
 #Source9: sshd@.service
 #Source10: sshd.socket
 #Source11: sshd.service
 #Source12: sshd-keygen@.service
-Source13: sshd-keygen
+#Source13: sshd-keygen
 #Source14: sshd.tmpfiles
-Source15: sshd-keygen.target
+#Source15: sshd-keygen.target
+
+Source80: sgug-sshd
 
 #https://bugzilla.mindrot.org/show_bug.cgi?id=2581
 #Patch100: openssh-6.7p1-coverity.patch
@@ -218,6 +220,7 @@ Patch964: openssh-8.0p1-openssl-kdf.patch
 #Patch966: openssh-8.0p1-agent-certs-sha2.patch
 
 Patch1000: openssh.sgifixes.patch
+Patch1001: openssh.sgifixes2.patch
 
 License: BSD
 #Requires: /sbin/nologin
@@ -430,6 +433,8 @@ cd ..
 
 #%patch100 -p1 -b .coverity
 
+%patch1001 -p1 -b .sgi1
+
 autoreconf
 %if %{pam_ssh_agent}
 cd pam_ssh_agent_auth-%{pam_ssh_agent_ver}
@@ -450,7 +455,7 @@ CFLAGS="$CFLAGS -fPIC"
 %else
 CFLAGS="$CFLAGS -fpic"
 %endif
-LDFLAGS="$RPM_LD_FLAGS"
+LDFLAGS="$LDFLAGS $RPM_LD_FLAGS"
 SAVE_LDFLAGS="$LDFLAGS"
 LDFLAGS="$LDFLAGS -pie -z relro -z now"
 
@@ -478,7 +483,8 @@ fi
 export ac_cv_func___b64_pton=no
 export ac_cv_func___b64_ntop=no
 
-export CPPFLAGS="-D_SGI_MP_SOURCE"
+CPPFLAGS="$CPPFLAGS -D_SGI_MP_SOURCE"
+export CPPFLAGS
 
 %configure \
 	--sysconfdir=%{_sysconfdir}/ssh \
@@ -493,8 +499,8 @@ export CPPFLAGS="-D_SGI_MP_SOURCE"
 	--with-ipaddr-display \
 	--with-pie=no \
 	--without-hardening `# The hardening flags are configured by system` \
-	--with-systemd \
 %if 0
+	--with-systemd \
 	--with-default-pkcs11-provider=yes \
 %endif
 %if %{ldap}
@@ -575,6 +581,7 @@ make tests
 
 %install
 rm -rf $RPM_BUILD_ROOT
+mkdir -p -m755 $RPM_BUILD_ROOT%{_sysconfdir}/init.d
 mkdir -p -m755 $RPM_BUILD_ROOT%{_sysconfdir}/ssh
 mkdir -p -m755 $RPM_BUILD_ROOT%{_sysconfdir}/ssh/ssh_config.d
 mkdir -p -m755 $RPM_BUILD_ROOT%{_libexecdir}/openssh
@@ -588,7 +595,7 @@ install -d $RPM_BUILD_ROOT%{_libexecdir}/openssh
 install -d $RPM_BUILD_ROOT%{_libdir}/fipscheck
 #install -m644 %{SOURCE2} $RPM_BUILD_ROOT/etc/pam.d/sshd
 #install -m644 %{SOURCE6} $RPM_BUILD_ROOT/etc/pam.d/ssh-keycat
-install -m644 %{SOURCE7} $RPM_BUILD_ROOT%{_sysconfdir}/sshd
+#install -m644 %{SOURCE7} $RPM_BUILD_ROOT%{_sysconfdir}/sshd
 #install -m644 ssh_config_redhat $RPM_BUILD_ROOT%{_sysconfdir}/ssh/ssh_config.d/05-redhat.conf
 #install -d -m755 $RPM_BUILD_ROOT/%{_unitdir}
 #install -m644 %{SOURCE9} $RPM_BUILD_ROOT/%{_unitdir}/sshd@.service
@@ -596,7 +603,7 @@ install -m644 %{SOURCE7} $RPM_BUILD_ROOT%{_sysconfdir}/sshd
 #install -m644 %{SOURCE11} $RPM_BUILD_ROOT/%{_unitdir}/sshd.service
 #install -m644 %{SOURCE12} $RPM_BUILD_ROOT/%{_unitdir}/sshd-keygen@.service
 #install -m644 %{SOURCE15} $RPM_BUILD_ROOT/%{_unitdir}/sshd-keygen.target
-install -m744 %{SOURCE13} $RPM_BUILD_ROOT/%{_libexecdir}/openssh/sshd-keygen
+#install -m744 %{SOURCE13} $RPM_BUILD_ROOT/%{_libexecdir}/openssh/sshd-keygen
 install -m755 contrib/ssh-copy-id $RPM_BUILD_ROOT%{_bindir}/
 install contrib/ssh-copy-id.1 $RPM_BUILD_ROOT%{_mandir}/man1/
 #install -m644 -D %{SOURCE14} $RPM_BUILD_ROOT%{_tmpfilesdir}/%{name}.conf
@@ -619,9 +626,12 @@ rm -f $RPM_BUILD_ROOT%{_mandir}/man8/ssh-pkcs11*
 rm -f $RPM_BUILD_ROOT/etc/profile.d/gnome-ssh-askpass.*
 %endif
 
+# put the init script in place
+install -m755 %{SOURCE80} $RPM_BUILD_ROOT%{_sysconfdir}/init.d/
+
 # Rewrite some things
 perl -pi -e "s|$RPM_BUILD_ROOT||g" $RPM_BUILD_ROOT%{_mandir}/man*/*
-perl -pi -e "s|/bin/bash|%{_bindir}/bash|g" $RPM_BUILD_ROOT%{_libexecdir}/%{name}/sshd-keygen
+#perl -pi -e "s|/bin/bash|%{_bindir}/bash|g" $RPM_BUILD_ROOT%{_libexecdir}/%{name}/sshd-keygen
 
 #%if %{pam_ssh_agent}
 #cd pam_ssh_agent_auth-%{pam_ssh_agent_ver}
@@ -633,26 +643,27 @@ perl -pi -e "s|/bin/bash|%{_bindir}/bash|g" $RPM_BUILD_ROOT%{_libexecdir}/%{name
 #getent group ssh_keys >/dev/null || groupadd -r ssh_keys || :
 
 %pre server
-#IRIX has no getent nor groupadd
-#getent group sshd >/dev/null || groupadd -g %{sshd_uid} -r sshd || :
-#getent passwd sshd >/dev/null || \
+# add group and user for privilege separation
 grep "sshd:x:%{sshd_uid}:" /etc/group >/dev/null || echo "sshd:x:%{sshd_uid}:" >> /etc/group || :
 grep "sshd:x:74:74" /etc/passwd >/dev/null || \
-#  useradd -c "Privilege-separated SSH" -u %{sshd_uid} -g sshd \
-#  -s /sbin/nologin -r -d /var/empty/sshd sshd 2> /dev/null || :
   /usr/sysadm/privbin/addUserAccount -l sshd -u %{sshd_uid} \
   -g %{sshd_gid} -G "Privilege-separated SSH" -S /bin/false \
   -H /var/empty/sshd 2> /dev/null || :
 
+[ -f /var/config/sgug-sshd ] || /sbin/chkconfig -f sgug-sshd on
 
-#%post server
-#%systemd_post sshd.service sshd.socket
+%post server
+/etc/chkconfig sshd && echo "WARNING: Non-SGUG sshd is enabled.  Run chkconfig sshd off, followed by /etc/init.d/sgug-sshd restart"
+# set up the init.d script
+ln -sf %{_sysconfdir}/init.d/sgug-sshd /etc/init.d/sgug-sshd
+# restart -- will not do anything if the user chkconfigd off
+/etc/init.d/sgug-sshd restart
 
-#%preun server
-#%systemd_preun sshd.service sshd.socket
+%preun server
+/etc/init.d/sgug-sshd stop
 
-#%postun server
-#%systemd_postun_with_restart sshd.service
+%postun server
+rm -f /etc/init.d/sgug-sshd /etc/config/sgug-sshd
 
 %files
 %license LICENCE
@@ -702,20 +713,21 @@ grep "sshd:x:74:74" /etc/passwd >/dev/null || \
 %attr(0755,root,root) %{_sbindir}/sshd
 #%attr(0644,root,root) %{_libdir}/fipscheck/sshd.hmac
 %attr(0755,root,root) %{_libexecdir}/openssh/sftp-server
-%attr(0755,root,root) %{_libexecdir}/openssh/sshd-keygen
+#%attr(0755,root,root) %{_libexecdir}/openssh/sshd-keygen
 %attr(0644,root,root) %{_mandir}/man5/sshd_config.5*
 %attr(0644,root,root) %{_mandir}/man5/moduli.5*
 %attr(0644,root,root) %{_mandir}/man8/sshd.8*
 %attr(0644,root,root) %{_mandir}/man8/sftp-server.8*
 %attr(0600,root,root) %config(noreplace) %{_sysconfdir}/ssh/sshd_config
 #%attr(0644,root,root) %config(noreplace) /etc/pam.d/sshd
-%attr(0640,root,root) %config(noreplace) %{_sysconfdir}/sshd
+#%attr(0640,root,root) %config(noreplace) %{_sysconfdir}/sshd
 #%attr(0644,root,root) %{_unitdir}/sshd.service
 #%attr(0644,root,root) %{_unitdir}/sshd@.service
 #%attr(0644,root,root) %{_unitdir}/sshd.socket
 #%attr(0644,root,root) %{_unitdir}/sshd-keygen@.service
 #%attr(0644,root,root) %{_unitdir}/sshd-keygen.target
 #%attr(0644,root,root) %{_tmpfilesdir}/openssh.conf
+%attr(0755,root,root) %config(noreplace) %{_sysconfdir}/init.d/sgug-sshd
 %endif
 
 %if %{ldap}
@@ -753,6 +765,9 @@ grep "sshd:x:74:74" /etc/passwd >/dev/null || \
 %endif
 
 %changelog
+* Sun Nov 07 2021 Vladimir Vukicevic <vladimir@pobox.com> - 8.1p1-12
+- Add IRIX init file and chkconfig, fix sshd_config
+
 * Tue Jun 16 2020 Daniel Hams <daniel.hams@gmail.com> - 8.1p1-11
 - Stop installing the redhat config that doesn''t work, fix the broken key reading
 


### PR DESCRIPTION
This fixes:

- sshd_config to remove PAM etc references, so that sshd successfully comes up 
- adds an entry to /etc/init.d called `sgug-sshd`, as well as a `chkconfig` flag
- if the flag doesn't exist, it's set to on by default and sgug-sshd is started (just like it would be on linux)
- removes some stuff from the rpm that shouldn't bein there (systemd units/scripts)
- 
The file in /etc is created as symlinks to a file in /usr/sgug by the postinst script; the rpm itself doesn't contain any files that go to /etc.
