### PR TITLE
Fix gdb to recognize ELFOSABI_IRIX

### DIFF
--- a/packages/gdb/SOURCES/gdb.elfirix.patch
+++ b/packages/gdb/SOURCES/gdb.elfirix.patch
@@ -1,0 +1,23 @@
+--- /usr/people/vladimir/tmp/mips-irix-tdep.c	2021-11-18 15:21:59.857384191 +0000
++++ gdb-7.6.2/gdb/mips-irix-tdep.c	2021-11-18 15:06:29.784909361 +0000
+@@ -28,6 +28,10 @@
+ #include "trad-frame.h"
+ #include "tramp-frame.h"
+ 
++#ifndef ELFOSABI_IRIX
++#define ELFOSABI_IRIX 8
++#endif
++
+ static void
+ mips_irix_elf_osabi_sniff_abi_tag_sections (bfd *abfd, asection *sect,
+                                             void *obj)
+@@ -63,6 +67,9 @@
+ 
+   elfosabi = elf_elfheader (abfd)->e_ident[EI_OSABI];
+ 
++  if (elfosabi == ELFOSABI_IRIX)
++    return GDB_OSABI_IRIX;
++
+   if (elfosabi == ELFOSABI_NONE)
+     {
+       /* When elfosabi is ELFOSABI_NONE (0), then the ELF structures in the

--- a/packages/gdb/SPECS/gdb.spec
+++ b/packages/gdb/SPECS/gdb.spec
@@ -17,6 +17,7 @@ URL: http://ftp.gnu.org/gnu/gdb/
 Source: http://ftp.gnu.org/gnu/gdb/gdb-%{version}.tar.gz
 
 Patch0: gdb762.sgifixups.patch
+Patch1: gdb.elfirix.patch
 
 BuildRequires: gcc, binutils
 BuildRequires: automake, autoconf, libtool, pkgconfig
@@ -33,6 +34,7 @@ The gnu debugger.
 %setup
 
 %patch0 -p1 -b .sgifixups
+%patch1 -p1 -b .elfirix
 
 # A place to generate our patch
 #exit 1

--- a/packages/gdb/SPECS/gdb.spec
+++ b/packages/gdb/SPECS/gdb.spec
@@ -11,7 +11,7 @@
 Summary: The GNU Debugger
 Name: gdb
 Version: 7.6.2
-Release: 8%{?dist}
+Release: 9%{?dist}
 License: GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL
 URL: http://ftp.gnu.org/gnu/gdb/
 Source: http://ftp.gnu.org/gnu/gdb/gdb-%{version}.tar.gz


### PR DESCRIPTION
gdb wasn't recognizing elf binaries with ELFOSABI_IRIX to actually be IRIX