### PR TITLE
Don't dlclose plugins, as some may have atexit handlers

### DIFF
--- a/packages/tdnf/SOURCES/tdnf-no-dlclose-plugins.patch
+++ b/packages/tdnf/SOURCES/tdnf-no-dlclose-plugins.patch
@@ -1,0 +1,11 @@
+--- tdnf-3.0.0-beta/client/plugins.c.orig	2021-11-19 14:57:30.307988836 +0000
++++ tdnf-3.0.0-beta/client/plugins.c	2021-11-19 14:57:15.299176437 +0000
+@@ -197,7 +197,7 @@
+     }
+     if (pPlugin->pModule)
+     {
+-        dlclose(pPlugin->pModule);
++        //dlclose(pPlugin->pModule);
+     }
+ }
+ 

--- a/packages/tdnf/SPECS/tdnf.spec
+++ b/packages/tdnf/SPECS/tdnf.spec
@@ -5,7 +5,7 @@
 Summary:        dnf/yum equivalent using C libs
 Name:           tdnf
 Version:        3.0.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Vendor:         VMware, Inc.
 Distribution:   Photon
 License:        LGPLv2.1,GPLv2
@@ -44,6 +44,7 @@ Patch104:		tdnf-client.sgifixes.patch
 Patch105:		tdnf-common-utils.sgifixes.patch
 Patch106:		tdnf-client-rpmtrans.sgifixes.patch
 Patch107:		tdnf-printfprecision.sgifixes.patch
+Patch108:		tdnf-no-dlclose-plugins.patch
 
 %description
 tdnf is a yum/dnf equivalent which uses libsolv and libcurl


### PR DESCRIPTION
Fixes gpg plugin atexit crash.