### PR TITLE
Exec should pass following arguments (after cmd) along

### DIFF
--- a/packages/sgugshell/SOURCES/sgugshell
+++ b/packages/sgugshell/SOURCES/sgugshell
@@ -61,5 +61,5 @@ if [[ $# -eq 0 ]] ; then
 else
 	# If ~/.sgug_bashrc exists, source it for our executable
 	[ -e $HOME/.sgug_bashrc ] && source $HOME/.sgug_bashrc
-	exec $1
+	exec $1 "${@: -1}"
 fi


### PR DESCRIPTION
EG for nedit to open a file on double click from fm when `/usr/sgug/bin/sgugshell nedit` is set as `Desktop >> Customize >> Utilities` text editor.